### PR TITLE
ansible midi mode v2

### DIFF
--- a/src/ansible_midi.c
+++ b/src/ansible_midi.c
@@ -17,7 +17,6 @@
 #include "init_common.h"
 #include "conf_tc_irq.h"
 
-
 // this
 #include "main.h"
 #include "ansible_midi.h"
@@ -1166,13 +1165,28 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 			print_dbg_ulong(d[1]);
 			print_dbg(" ");
 			print_dbg_ulong(d[2]);
-			v = uclip(d[2], 0, 16);
+			v = uclip(d[2], 1, 32);  // NB: 32 is maximum for euclidean tables
 			if (d[1] == 0) {
 				for (i = 0; i < 4; i++)
 					arp_player_set_division(&(player[i]), v, &player_behavior);
 			}
 			else {
 				arp_player_set_division(&(player[d[1]-1]), v, &player_behavior);
+			}
+			break;
+
+		case II_ARP_FILL:
+			print_dbg("\r\narp ii fill: ");
+			print_dbg_ulong(d[1]);
+			print_dbg(" ");
+			print_dbg_ulong(d[2]);
+			v = uclip(d[2], 0, 32);  // NB: 32 is maximum for euclidean tables
+			if (d[1] == 0) {
+				for (i = 0; i < 4; i++)
+					arp_player_set_fill(&(player[i]), v);
+			}
+			else {
+				arp_player_set_fill(&(player[d[1]-1]), v);
 			}
 			break;
 

--- a/src/ansible_midi.c
+++ b/src/ansible_midi.c
@@ -1099,16 +1099,16 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 		case II_ARP_STYLE:
 			p1 = uclip(d[1], eStylePlayed, eStyleRandom);
 
-			print_dbg("\r\narp ii style: ");
-			print_dbg_ulong(p1);
+			// print_dbg("\r\narp ii style: ");
+			// print_dbg_ulong(p1);
 
 			arp_state.style = p1;
 			arp_rebuild(&chord);
 			break;
 			
 		case II_ARP_HOLD:
-			print_dbg("\r\narp ii hold: ");
-			print_dbg_ulong(d[1]);
+			// print_dbg("\r\narp ii hold: ");
+			// print_dbg_ulong(d[1]);
 
 			arp_state_set_hold(d[1] > 0);
 			break;
@@ -1118,12 +1118,12 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 			p1 = uclip(d[2], 0, 8);
 			s = sclip((int16_t)((d[3] << 8) + d[4]), -24, 24);
 			
-			print_dbg("\r\narp ii rpt: ");
-			print_dbg_ulong(v);
-			print_dbg(" ");
-			print_dbg_ulong(p1);
-			print_dbg(" ");
-			print_dbg_hex(s);
+			// print_dbg("\r\narp ii rpt: ");
+			// print_dbg_ulong(v);
+			// print_dbg(" ");
+			// print_dbg_ulong(p1);
+			// print_dbg(" ");
+			// print_dbg_hex(s);
 
 			if (v == 0) {
 				for (i = 0; i < 4; i++)
@@ -1140,10 +1140,10 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 			v = uclip(d[1], 0, 4);
 			p1 = uclip(d[2], 0, 127);
 
-			print_dbg("\r\narp ii gate: ");
-			print_dbg_ulong(v);
-			print_dbg(" ");
-			print_dbg_ulong(p1);
+			// print_dbg("\r\narp ii gate: ");
+			// print_dbg_ulong(v);
+			// print_dbg(" ");
+			// print_dbg_ulong(p1);
 			// FIXME: the gate width input range is 0-127, should tt range
 			// be non-midi like say 0-100?
 
@@ -1160,10 +1160,10 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 			v = uclip(d[1], 0, 4);
 			p1 = uclip(d[2], 1, 32);  // NB: 32 is maximum for euclidean tables
 
-			print_dbg("\r\narp ii div: ");
-			print_dbg_ulong(v);
-			print_dbg(" ");
-			print_dbg_ulong(p1);
+			// print_dbg("\r\narp ii div: ");
+			// print_dbg_ulong(v);
+			// print_dbg(" ");
+			// print_dbg_ulong(p1);
 
 			if (v == 0) {
 				for (i = 0; i < 4; i++)
@@ -1178,10 +1178,10 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 			v = uclip(d[1], 0, 4);
 			p1 = uclip(d[2], 0, 32);  // NB: 32 is maximum for euclidean tables
 
-			print_dbg("\r\narp ii fill: ");
-			print_dbg_ulong(v);
-			print_dbg(" ");
-			print_dbg_ulong(p1);
+			// print_dbg("\r\narp ii fill: ");
+			// print_dbg_ulong(v);
+			// print_dbg(" ");
+			// print_dbg_ulong(p1);
 
 			if (v == 0) {
 				for (i = 0; i < 4; i++)
@@ -1196,10 +1196,10 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 			v = uclip(d[1], 0, 4);
 			s = sclip((int16_t)((d[2] << 8) + d[3]), -32, 32);
 
-			print_dbg("\r\narp ii rot: ");
-			print_dbg_ulong(v);
-			print_dbg(" ");
-			print_dbg_hex(s);
+			// print_dbg("\r\narp ii rot: ");
+			// print_dbg_ulong(v);
+			// print_dbg(" ");
+			// print_dbg_hex(s);
 
 			if (v == 0) {
 				for (i = 0; i < 4; i++)
@@ -1216,14 +1216,14 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 			p2 = uclip(d[3], 1, 32);
 			s = sclip((int16_t)((d[4] << 8) + d[5]), -32, 32);
 
-			print_dbg("\r\narp ii er: ");
-			print_dbg_ulong(v);
-			print_dbg(" ");
-			print_dbg_ulong(p1);
-			print_dbg(" ");
-			print_dbg_ulong(p2);
-			print_dbg(" ");
-			print_dbg_hex(s);
+			// print_dbg("\r\narp ii er: ");
+			// print_dbg_ulong(v);
+			// print_dbg(" ");
+			// print_dbg_ulong(p1);
+			// print_dbg(" ");
+			// print_dbg_ulong(p2);
+			// print_dbg(" ");
+			// print_dbg_hex(s);
 
 			if (v == 0) {
 				for (i = 0; i < 4; i++) {
@@ -1245,10 +1245,10 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 			v = uclip(d[1], 0, 4);
 			s = sclip((int16_t)((d[2] << 8) + d[3]), 0, 2000);
 
-			print_dbg("\r\narp ii slew: ");
-			print_dbg_ulong(v);
-			print_dbg(" ");
-			print_dbg_ulong(s);
+			// print_dbg("\r\narp ii slew: ");
+			// print_dbg_ulong(v);
+			// print_dbg(" ");
+			// print_dbg_ulong(s);
 
 			if (v == 0) {
 				for (i = 0; i < 4; i++)
@@ -1262,8 +1262,8 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 		case II_ARP_RESET:
 			v = uclip(d[1], 0, 4);
 
-			print_dbg("\r\narp ii reset: ");
-			print_dbg_ulong(v);
+			// print_dbg("\r\narp ii reset: ");
+			// print_dbg_ulong(v);
 
 			if (v == 0) {
 				for (i = 0; i < 4; i++)
@@ -1278,10 +1278,10 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 			v = uclip(d[1], 0, 4);
 			s = (int16_t)((d[2] << 8) + d[3]);
 
-			print_dbg("\r\narp ii shift: ");
-			print_dbg_ulong(v);
-			print_dbg(" ");
-			print_dbg_hex(s);
+			// print_dbg("\r\narp ii shift: ");
+			// print_dbg_ulong(v);
+			// print_dbg(" ");
+			// print_dbg_hex(s);
 
 			if (v == 0) {
 				for (i = 0; i < 4; i++)

--- a/src/ansible_midi.c
+++ b/src/ansible_midi.c
@@ -297,7 +297,7 @@ void handler_MidiFrontShort(s32 data) {
 }
 
 void handler_MidiFrontLong(s32 data) {
-	if(ansible_mode == mMidiStandard)
+	if (ansible_mode == mMidiStandard)
 		set_mode(mMidiArp);
 	else
 		set_mode(mMidiStandard);
@@ -1134,7 +1134,7 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 			break;
 			
 		case II_ARP_DIST:
-			s = (d[2] << 8) | d[3];
+			s = sclip((int16_t)((d[2] << 8) + d[3]), -24, 24);
 			print_dbg("\r\narp ii dist: ");
 			print_dbg_ulong(d[1]);
 			print_dbg(" ");
@@ -1153,7 +1153,8 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 			print_dbg_ulong(d[1]);
 			print_dbg(" ");
 			print_dbg_ulong(d[2]);
-			// FIXME: the gate width input range is 0-127, should tt range be non-midi like say 0-100?
+			// FIXME: the gate width input range is 0-127, should tt range
+			// be non-midi like say 0-100?
 			v = uclip(d[2], 0, 127);
 			if (d[1] == 0) {
 				for (i = 0; i < 4; i++)
@@ -1188,7 +1189,7 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 			break;
 
 		case II_ARP_SLEW:
-			s = sclip((d[2] << 8) + d[3], 0, 2000);
+			s = sclip((int16_t)((d[2] << 8) + d[3]), 0, 2000);
 			print_dbg("\r\narp ii slew: ");
 			print_dbg_ulong(d[1]);
 			print_dbg(" ");
@@ -1221,7 +1222,7 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 			break;
 
 		case II_ARP_TRANS:
-			s = (d[2] << 8) + d[3];
+			s = (int16_t)((d[2] << 8) + d[3]);
 			print_dbg("\r\narp ii trans: ");
 			print_dbg_ulong(d[1]);
 			print_dbg(" ");

--- a/src/ansible_midi.c
+++ b/src/ansible_midi.c
@@ -260,7 +260,7 @@ void set_mode_midi(void) {
 	sync_source = eClockInternal;
 
 	midi_clock_init(&midi_clock);
-	midi_clock_set_div(&midi_clock, 2); // 8th notes; TODO; make configurable?
+	midi_clock_set_div(&midi_clock, 4); // 16th notes (24 ppq / 4 == 6 pp 16th)
 
 	key_state.key1 = key_state.key2 = key_state.front = 0;
 	key_state.normaled = !gpio_get_pin_value(B10);

--- a/src/ansible_midi.c
+++ b/src/ansible_midi.c
@@ -1091,194 +1091,204 @@ void clock_midi_arp(uint8_t phase) {
 
 void ii_midi_arp(uint8_t *d, uint8_t l) {
 	arp_player_t *p;
-	u8 i, v1, v2, v3;
+	u8 i, v, p1, p2;
 	s16 s;
 
 	if (l) {
 		switch (d[0]) {
 		case II_ARP_STYLE:
-			print_dbg("\r\narp ii style: ");
-			print_dbg_ulong(d[1]);
-			print_dbg(" ");
-			print_dbg_ulong(d[2]);
+			p1 = uclip(d[1], eStylePlayed, eStyleRandom);
 
-			// TODO: allow each player to have a different sequence
-			v1 = uclip(d[2], eStylePlayed, eStyleRandom);
-			arp_state.style = v1;
+			print_dbg("\r\narp ii style: ");
+			print_dbg_ulong(p1);
+
+			arp_state.style = p1;
 			arp_rebuild(&chord);
 			break;
 			
 		case II_ARP_HOLD:
 			print_dbg("\r\narp ii hold: ");
 			print_dbg_ulong(d[1]);
+
 			arp_state_set_hold(d[1] > 0);
 			break;
+
+		case II_ARP_RPT:
+			v = uclip(d[1], 0, 4);
+			p1 = uclip(d[2], 0, 8);
+			s = sclip((int16_t)((d[3] << 8) + d[4]), -24, 24);
 			
-		case II_ARP_STEPS:
-			print_dbg("\r\narp ii steps: ");
-			print_dbg_ulong(d[1]);
+			print_dbg("\r\narp ii rpt: ");
+			print_dbg_ulong(v);
 			print_dbg(" ");
-			v1 = uclip(d[2], 0, 8);
-			print_dbg_ulong(v1);
-			if (d[1] == 0) {
-				for (i = 0; i < 4; i++)
-					arp_player_set_steps(&(player[i]), v1);
-			}
-			else {
-				arp_player_set_steps(&(player[d[1]-1]), v1);
-			}
-			break;
-			
-		case II_ARP_DIST:
-			s = sclip((int16_t)((d[2] << 8) + d[3]), -24, 24);
-			print_dbg("\r\narp ii dist: ");
-			print_dbg_ulong(d[1]);
+			print_dbg_ulong(p1);
 			print_dbg(" ");
 			print_dbg_hex(s);
-			if (d[1] == 0) {
+
+			if (v == 0) {
 				for (i = 0; i < 4; i++)
+					arp_player_set_steps(&(player[i]), p1);
 					arp_player_set_offset(&(player[i]), s);
 			}
 			else {
-				arp_player_set_offset(&(player[d[1]-1]), s);
+				arp_player_set_steps(&(player[v-1]), p1);
+				arp_player_set_offset(&(player[v-1]), s);
 			}
 			break;
 			
 		case II_ARP_GATE:
+			v = uclip(d[1], 0, 4);
+			p1 = uclip(d[2], 0, 127);
+
 			print_dbg("\r\narp ii gate: ");
-			print_dbg_ulong(d[1]);
+			print_dbg_ulong(v);
 			print_dbg(" ");
-			print_dbg_ulong(d[2]);
+			print_dbg_ulong(p1);
 			// FIXME: the gate width input range is 0-127, should tt range
 			// be non-midi like say 0-100?
-			v1 = uclip(d[2], 0, 127);
-			if (d[1] == 0) {
+
+			if (v == 0) {
 				for (i = 0; i < 4; i++)
-					arp_player_set_gate_width(&(player[i]), v1);
+					arp_player_set_gate_width(&(player[i]), p1);
 			}
 			else {
-				arp_player_set_gate_width(&(player[d[1]-1]), v1);
+				arp_player_set_gate_width(&(player[v-1]), p1);
 			}
 			break;
 
 		case II_ARP_DIV:
+			v = uclip(d[1], 0, 4);
+			p1 = uclip(d[2], 1, 32);  // NB: 32 is maximum for euclidean tables
+
 			print_dbg("\r\narp ii div: ");
-			print_dbg_ulong(d[1]);
+			print_dbg_ulong(v);
 			print_dbg(" ");
-			print_dbg_ulong(d[2]);
-			v1 = uclip(d[2], 1, 32);  // NB: 32 is maximum for euclidean tables
-			if (d[1] == 0) {
+			print_dbg_ulong(p1);
+
+			if (v == 0) {
 				for (i = 0; i < 4; i++)
-					arp_player_set_division(&(player[i]), v1, &player_behavior);
+					arp_player_set_division(&(player[i]), p1, &player_behavior);
 			}
 			else {
-				arp_player_set_division(&(player[d[1]-1]), v1, &player_behavior);
+				arp_player_set_division(&(player[v-1]), p1, &player_behavior);
 			}
 			break;
 
 		case II_ARP_FILL:
+			v = uclip(d[1], 0, 4);
+			p1 = uclip(d[2], 0, 32);  // NB: 32 is maximum for euclidean tables
+
 			print_dbg("\r\narp ii fill: ");
-			print_dbg_ulong(d[1]);
+			print_dbg_ulong(v);
 			print_dbg(" ");
-			print_dbg_ulong(d[2]);
-			v1 = uclip(d[2], 0, 32);  // NB: 32 is maximum for euclidean tables
-			if (d[1] == 0) {
+			print_dbg_ulong(p1);
+
+			if (v == 0) {
 				for (i = 0; i < 4; i++)
-					arp_player_set_fill(&(player[i]), v1);
+					arp_player_set_fill(&(player[i]), p1);
 			}
 			else {
-				arp_player_set_fill(&(player[d[1]-1]), v1);
+				arp_player_set_fill(&(player[v-1]), p1);
 			}
 			break;
 
 		case II_ARP_ROT:
+			v = uclip(d[1], 0, 4);
 			s = sclip((int16_t)((d[2] << 8) + d[3]), -32, 32);
+
 			print_dbg("\r\narp ii rot: ");
-			print_dbg_ulong(d[1]);
+			print_dbg_ulong(v);
 			print_dbg(" ");
 			print_dbg_hex(s);
-			if (d[1] == 0) {
+
+			if (v == 0) {
 				for (i = 0; i < 4; i++)
 					arp_player_set_rotation(&(player[i]), s);
 			}
 			else {
-				arp_player_set_rotation(&(player[d[1]-1]), s);
+				arp_player_set_rotation(&(player[v-1]), s);
 			}
 			break;
 
 		case II_ARP_ER:
-			v2 = uclip(d[2], 0, 32);  // NB: 32 is maximum for euclidean tables
-			v3 = uclip(d[3], 1, 32);
+			v = uclip(d[1], 0, 4);
+			p1 = uclip(d[2], 0, 32);  // NB: 32 is maximum for euclidean tables
+			p2 = uclip(d[3], 1, 32);
 			s = sclip((int16_t)((d[4] << 8) + d[5]), -32, 32);
+
 			print_dbg("\r\narp ii er: ");
-			print_dbg_ulong(d[1]);
+			print_dbg_ulong(v);
 			print_dbg(" ");
-			print_dbg_ulong(v2);
+			print_dbg_ulong(p1);
 			print_dbg(" ");
-			print_dbg_ulong(v3);
+			print_dbg_ulong(p2);
 			print_dbg(" ");
 			print_dbg_hex(s);
-			if (d[1] == 0) {
+
+			if (v == 0) {
 				for (i = 0; i < 4; i++) {
 					p = &(player[i]);
-					arp_player_set_division(p, v3, &player_behavior);
-					arp_player_set_fill(p, v2);
+					arp_player_set_division(p, p2, &player_behavior);
+					arp_player_set_fill(p, p1);
 					arp_player_set_rotation(p, s);
 				}
 			}
 			else {
-				p = &(player[d[1]-1]);
-				arp_player_set_division(p, v3, &player_behavior);
-				arp_player_set_fill(p, v2);
+				p = &(player[v-1]);
+				arp_player_set_division(p, p2, &player_behavior);
+				arp_player_set_fill(p, p1);
 				arp_player_set_rotation(p, s);
 			}
 			break;
 
 		case II_ARP_SLEW:
+			v = uclip(d[1], 0, 4);
 			s = sclip((int16_t)((d[2] << 8) + d[3]), 0, 2000);
+
 			print_dbg("\r\narp ii slew: ");
-			print_dbg_ulong(d[1]);
+			print_dbg_ulong(v);
 			print_dbg(" ");
 			print_dbg_ulong(s);
-			if (d[1] == 0) {
+
+			if (v == 0) {
 				for (i = 0; i < 4; i++)
 					dac_set_slew(i, s);
 			}
 			else {
-				dac_set_slew(d[1]-1, s);
+				dac_set_slew(v-1, s);
 			}
 			break;
 
-		case II_ARP_PULSE:
-			print_dbg("\r\narp ii pulse: ");
-			print_dbg_ulong(d[1]);
-			// TODO - ack can't do this without a phase value
-			break;
-
 		case II_ARP_RESET:
+			v = uclip(d[1], 0, 4);
+
 			print_dbg("\r\narp ii reset: ");
-			print_dbg_ulong(d[1]);
-			if (d[1] == 0) {
+			print_dbg_ulong(v);
+
+			if (v == 0) {
 				for (i = 0; i < 4; i++)
 					arp_player_reset(&(player[i]), &player_behavior);
 			}
 			else {
-				arp_player_reset(&(player[d[1]-1]), &player_behavior);
+				arp_player_reset(&(player[v-1]), &player_behavior);
 			}
 			break;
 
-		case II_ARP_TRANS:
+		case II_ARP_SHIFT:
+			v = uclip(d[1], 0, 4);
 			s = (int16_t)((d[2] << 8) + d[3]);
-			print_dbg("\r\narp ii trans: ");
-			print_dbg_ulong(d[1]);
+
+			print_dbg("\r\narp ii shift: ");
+			print_dbg_ulong(v);
 			print_dbg(" ");
 			print_dbg_hex(s);
-			if (d[1] == 0) {
+
+			if (v == 0) {
 				for (i = 0; i < 4; i++)
 					dac_set_off(i, s);
 			}
 			else {
-				dac_set_off(d[1]-1, s);
+				dac_set_off(v-1, s);
 			}
 			break;
 

--- a/src/ansible_midi.c
+++ b/src/ansible_midi.c
@@ -28,6 +28,11 @@
 #define MONO_MOD_CV 3
 #define MONO_BEND_CV 3
 
+// NB: default to a -2 octave shift for pitch to help people with
+// small keyboards keep the osc pitch knob closer to mid range.
+// -3277 == N -24 on tt
+#define DEFAULT_PITCH_SHIFT -3277
+
 //------------------------------
 //------ types
 
@@ -484,7 +489,7 @@ void default_midi_standard(void) {
 
 	fixed_write_mapping(&(f.midi_standard_state.fixed), &m);
 
-	flashc_memset16((void*)&(f.midi_standard_state.shift), 0, 2, true);
+	flashc_memset16((void*)&(f.midi_standard_state.shift), DEFAULT_PITCH_SHIFT, 2, true);
 	flashc_memset16((void*)&(f.midi_standard_state.slew), 0, 2, true);
 }
 
@@ -1128,7 +1133,7 @@ void default_midi_arp() {
 		flashc_memset8((void*)&(f.midi_arp_state.p[i].offset), 12, 1, true);
 
 		flashc_memset16((void*)&(f.midi_arp_state.p[i].slew), 0, 2, true);
-		flashc_memset16((void*)&(f.midi_arp_state.p[i].shift), 0, 2, true);
+		flashc_memset16((void*)&(f.midi_arp_state.p[i].shift), DEFAULT_PITCH_SHIFT, 2, true);
 	}
 }
 

--- a/src/ansible_midi.h
+++ b/src/ansible_midi.h
@@ -1,5 +1,12 @@
 #pragma once
 
+// NB: NOTE_POOL_SIZE and CHORD_MAX_NOTES (in libavr32) need to match
+// in order for the as played arp logic to work correctly.
+//
+// the defines represent the maximum number of notes tracked in legato
+// note handling and the maximum number of (input) notes to the arp
+// logic respectively.
+
 // libavr32
 #include "arp.h"
 

--- a/src/ansible_midi.h
+++ b/src/ansible_midi.h
@@ -31,15 +31,28 @@ typedef struct {
 	uint32_t clock_period;
 	u8 voicing;
 	fixed_mapping_t fixed;
+	s16 shift;   // tuning/dac offset
+	s16 slew;    // pitch cv slew (ms)
 } midi_standard_state_t;
+
+typedef struct {
+	u8 fill;
+	u8 division;
+	s8 rotation;
+	u8 gate;
+	u8 steps;
+	u8 offset;
+
+	s16 slew;
+	s16 shift;
+} midi_arp_player_state_t;
 
 // arp mode value saved to nvram
 typedef struct {
 	uint32_t clock_period;
 	u8 style;    // NB: not using arp_style as type because enums have vairable size
 	bool hold;   // if true new notes add to chord if at least one note in chord is still held
-	u8 steps;    // number of steps (repeats?) of the arp pattern
-	s8 offset;   // number of semitones to transpose by per step; [-24,24] or voltage offsets?
+	midi_arp_player_state_t p[4];
 } midi_arp_state_t;
 
 void set_mode_midi(void);

--- a/src/ansible_midi.h
+++ b/src/ansible_midi.h
@@ -30,6 +30,9 @@ typedef struct {
 typedef struct {
 	uint32_t clock_period;
 	u8 style;    // NB: not using arp_style as type because enums have vairable size
+	bool hold;   // if true new notes add to chord if at least one note in chord is still held
+	u8 steps;    // number of steps (repeats?) of the arp pattern
+	s8 offset;   // number of semitones to transpose by per step; [-24,24] or voltage offsets?
 } midi_arp_state_t;
 
 void set_mode_midi(void);

--- a/src/config.mk
+++ b/src/config.mk
@@ -72,6 +72,8 @@ CSRCS = \
        ../libavr32/src/adc.c     \
        ../libavr32/src/arp.c     \
        ../libavr32/src/dac.c     \
+       ../libavr32/src/euclidean/data.c \
+       ../libavr32/src/euclidean/euclidean.c \
        ../libavr32/src/events.c     \
        ../libavr32/src/i2c.c     \
        ../libavr32/src/init_ansible.c \
@@ -105,8 +107,8 @@ CSRCS = \
        avr32/utils/debug/print_funcs.c                    \
        common/services/usb/class/msc/host/uhi_msc.c       \
        common/services/usb/class/msc/host/uhi_msc_mem.c   \
-       common/services/spi/uc3_spi/spi_master.c \
-       common/services/usb/uhc/uhc.c \
+       common/services/spi/uc3_spi/spi_master.c           \
+       common/services/usb/uhc/uhc.c                      \
        common/services/clock/uc3b0_b1/sysclk.c  
 
 # List of assembler source files.
@@ -117,14 +119,14 @@ ASSRCS = \
 
 # List of include paths.
 INC_PATH = \
-       ../../src           \
-       ../src                                        \
-       ../src/usb \
-       ../src/usb/ftdi \
-       ../src/usb/hid \
-       ../src/usb/midi \
-       ../conf      \
-       ../conf/trilogy \
+       ../../src                                          \
+       ../src                                             \
+       ../src/usb                                         \
+       ../src/usb/ftdi                                    \
+       ../src/usb/hid                                     \
+       ../src/usb/midi                                    \
+       ../conf                                            \
+       ../conf/trilogy                                    \
        avr32/boards                                       \
        avr32/drivers/cpu/cycle_counter                    \
        avr32/drivers/flashc                               \
@@ -140,16 +142,16 @@ INC_PATH = \
        avr32/utils/debug                                  \
        avr32/utils/preprocessor                           \
        common/boards                                      \
-       common/boards/user_board \
+       common/boards/user_board                           \
        common/services/storage/ctrl_access                \
        common/services/clock                              \
        common/services/delay                              \
-       common/services/usb/ \
-       common/services/usb/uhc \
+       common/services/usb/                               \
+       common/services/usb/uhc                            \
        common/services/usb/class/msc                      \
        common/services/usb/class/msc/host                 \
        common/services/usb/class/hid                      \
-       common/services/spi/uc3_spi \
+       common/services/spi/uc3_spi                        \
        common/utils                                       
 
 # Additional search paths for libraries.


### PR DESCRIPTION
this is the **second** of three PRs:
* https://github.com/monome/libavr32/pull/24
* this
* teletype

_**the libavr32 changes must be merged before this one**_

general changes:
- full teletype support (documentation forthcoming)
- better config save gesture (two keys instead of one)
- midi clock output changed from 1/8th to 1/16th notes
- (nearly) all parameters saved/restored between mode switch and preset config in flash
- default note to cv mapping is -2 octaves

arp mode:
- [new] key 2 + key 1 toggles on hold
- [new] pattern style (as played)
- [new] pattern steps (0 to 8)
- [new] pattern offset (-24 to +24 semitones)
- no longer restart arp pattern when the keys change (makes arp useable imho)
- pitch slewing
- tuning offset

standard mode:
- pitch slewing 
- tuning offset