### PR TITLE
kria: pattern quantization

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -1738,8 +1738,12 @@ void refresh_kria(void) {
 		default:
 			memset(monomeLedBuffer, 3, 16);
 			monomeLedBuffer[k.pattern] = L1;
-			if (defer_pattern && k.p[k.pattern].len)
-				monomeLedBuffer[deferred_pattern] = 6;
+			if (k.p[k.pattern].len) {
+				if (defer_pattern)
+					monomeLedBuffer[deferred_pattern] = 6;
+				memset(monomeLedBuffer + R1, 3, k.p[k.pattern].len);
+				monomeLedBuffer[R1 + (pattern_pos / k.p[k.pattern].len_mul)] = 6;
+			}
 		}
 		break;
 	default: break;

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -38,6 +38,8 @@ typedef struct {
 
 typedef struct {
 	kria_track t[4];
+	u8 len;
+	u8 len_mul;
 	u8 scale;
 } kria_pattern;
 


### PR DESCRIPTION
Here's my stab at pattern quantization for kria.

- It is off by default, and settings are stored per-pattern. It is accessed by holding down the time modifier button while on the pattern view.
- There are two rows, the second row acts as a multiplier for the top row's value, so you can quantize to greater than the length of one pattern.
- Turn it on simply by selecting a value in the top row, turn it off by selecting the currently selected value in the top row.
- When active, the pattern will reset when the currently set quantization length is reached. When a new pattern is selected, the current pattern will play out until the currently set quantization length is reached before switching to the newly selected pattern.