### PR TITLE
update IRQ functions to sync with libavr32 changes

### DIFF
--- a/src/ansible_midi.c
+++ b/src/ansible_midi.c
@@ -17,6 +17,7 @@
 
 #include "init_common.h"
 #include "conf_tc_irq.h"
+#include "interrupts.h"
 
 // this
 #include "main.h"
@@ -1220,8 +1221,8 @@ static bool arp_seq_switch_active(void) {
 	arp_seq_t *last_seq;
 	bool switched = false;
 
-	// disable timer interrupts
-	timers_pause();
+	// disable interrupts
+	u8 irq_flags = irqs_pause();
 
 	if (next_seq->state == eSeqWaiting) {
 		next_seq->state = eSeqPlaying;
@@ -1232,8 +1233,8 @@ static bool arp_seq_switch_active(void) {
 		switched = true;
 	}
 
-	// enable timer interrupts
-	timers_resume();
+	// enable interrupts
+	irqs_resume(irq_flags);
 
 	return switched;
 }

--- a/src/config.mk
+++ b/src/config.mk
@@ -78,6 +78,7 @@ CSRCS = \
        ../libavr32/src/i2c.c     \
        ../libavr32/src/init_ansible.c \
        ../libavr32/src/init_common.c \
+       ../libavr32/src/interrupts.c \
        ../libavr32/src/midi_common.c \
        ../libavr32/src/monome.c \
        ../libavr32/src/music.c \


### PR DESCRIPTION
updated for libavr32 changes to IRQ pause/resume functions. (this is currently causing travis to fail for libavr32.)

i don't have ansible hardware so can't really test it!

@ngwese seems like midi would be directly affected if i did this wrong...