### PR TITLE
fix for tied notes

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -534,7 +534,7 @@ void clock_kria_track( uint8_t trackNum ) {
 	u8* trackIndex = &kria_track_indices[trackNum];
 
 	if(kria_next_step(trackNum, mDur)) {
-		f32 clock_scale = (clock_deltas[trackNum] * track->tmul[mTr]) / (f32)384.0;
+		f32 clock_scale = (clock_deltas[trackNum] * track->tmul[mTr]) / (f32)380.0;
 		f32 uncscaled = (track->dur[pos[trackNum][mDur]]+1) * (track->dur_mul<<2);
 		dur[trackNum] = (u16)(uncscaled * clock_scale);
 	}


### PR DESCRIPTION
at max duration tied notes still had gaps, this should fix it. checked with oscilloscope, no gaps as far as i can tell. using value of 381 or higher still produces gaps.