### PR TITLE
kria: forward/reverse/triangle/drunk direction select

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -346,6 +346,8 @@ void default_kria() {
 	// memset(k.p[0].t[0].pnote, 3, 16);
 	// memset(k.p[0].t[0].pdur, 3, 16);
 	k.p[0].t[0].dur_mul = 4;
+	k.p[0].t[0].direction = krDirForward;
+	k.p[0].t[0].advancing = true;
 	memset(k.p[0].t[0].lstart, 0, KRIA_NUM_PARAMS);
 	memset(k.p[0].t[0].lend, 5, KRIA_NUM_PARAMS);
 	memset(k.p[0].t[0].llen, 6, KRIA_NUM_PARAMS);
@@ -439,14 +441,55 @@ bool kria_next_step(uint8_t t, uint8_t p) {
 	pos_mul[t][p]++;
 
 	if(pos_mul[t][p] >= k.p[k.pattern].t[t].tmul[p]) {
-		if(pos[t][p] == k.p[k.pattern].t[t].lend[p])
-			pos[t][p] = k.p[k.pattern].t[t].lstart[p];
-		else {
-			pos[t][p]++;
-			if(pos[t][p] > 15)
-				pos[t][p] = 0;
-		}
 		pos_mul[t][p] = 0;
+
+		switch (k.p[k.pattern].t[t].direction) {
+			default:
+			case krDirForward: forward:
+				if(pos[t][p] == k.p[k.pattern].t[t].lend[p]) {
+					pos[t][p] = k.p[k.pattern].t[t].lstart[p];
+				}
+				else {
+					pos[t][p]++;
+					if(pos[t][p] > 15) {
+						pos[t][p] = 0;
+					}
+				}
+				break;
+			case krDirReverse: reverse:
+				if(pos[t][p] == k.p[k.pattern].t[t].lstart[p]) {
+					pos[t][p] = k.p[k.pattern].t[t].lend[p];
+				}
+				else {
+					pos[t][p]--;
+					if(pos[t][p] < 0) {
+						pos[t][p] = 15;
+					}
+				}
+				break;
+			case krDirTriangle:
+				if (pos[t][p] == k.p[k.pattern].t[t].lend[p]) {
+					k.p[k.pattern].t[t].advancing = false;
+				}
+				if (pos[t][p] == k.p[k.pattern].t[t].lstart[p]) {
+					k.p[k.pattern].t[t].advancing = true;
+				}
+				if (k.p[k.pattern].t[t].advancing) {
+					goto forward;
+				}
+				else {
+					goto reverse;
+				}
+				break;
+			case krDirDrunk:
+				if ((rnd() & 0xff) > 128) {
+					goto forward;
+				} else {
+					goto reverse;
+				}
+				break;
+		}
+
 		switch(k.p[k.pattern].t[t].p[p][pos[t][p]]) {
 		case 0:
 			return false;
@@ -1663,11 +1706,16 @@ void handler_KriaGridKey(s32 data) {
 				break;
 			case mScale:
 				if(z) {
-					// tt clocking stuff added here
-					if ( y == 0 && x < 4 )
-					{
-						kria_tt_clocked[x] = !kria_tt_clocked[x];
-					}
+					if ( y < 4 && x < 5 ) {
+						// tt clocking stuff added here
+						if ( x == 0){
+							kria_tt_clocked[y] = !kria_tt_clocked[y];
+						}
+
+						if (x > 0 && x < 5) {
+							k.p[k.pattern].t[y].direction = x - 1;
+						}
+				        }
 					else if(x < 8) {
 						if(y > 4)
 							k.p[k.pattern].scale = (y - 5) * 8 + x;
@@ -2300,11 +2348,12 @@ void refresh_kria_glide(void) {
 }
 
 void refresh_kria_scale(void) {
-	// shoehorning my track clocking feature here
-	for ( uint8_t i=0; i<4; i++ )
-	{
-		// if teletype clocking is enabled, its brighter
-		monomeLedBuffer[i] = kria_tt_clocked[i] ? L1 : L0;
+	for ( uint8_t y=0; y<4; y++ ) {
+		// if teletype clocking is enabled, track is brighter
+		monomeLedBuffer[0+16*y] = kria_tt_clocked[y] ? L1 : L0;
+		for ( uint8_t x=1; x<5; x++ ) {
+			monomeLedBuffer[x+16*y] = k.p[k.pattern].t[y].direction == x - 1 ? L1 : L0;
+		}
 	}
 
 	// vertical bar dividing the left and right half

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -15,6 +15,13 @@
 #define KRIA_NUM_PARAMS 7
 #define KRIA_NUM_PATTERNS 16
 
+typedef enum {
+  krDirForward,
+  krDirReverse,
+  krDirTriangle,
+  krDirDrunk,
+} kria_direction;
+
 typedef struct {
 	u8 tr[16];
 	u8 oct[16];
@@ -32,6 +39,8 @@ typedef struct {
 	// u8 pdur[16];
 
 	u8 dur_mul;
+	kria_direction direction;
+	bool advancing;
 
 	u8 lstart[KRIA_NUM_PARAMS];
 	u8 lend[KRIA_NUM_PARAMS];


### PR DESCRIPTION
As proposed in [this](https://llllllll.co/t/ansible-kria-feature-requests/4846/93) post:
* Add a per-track direction select for forward/reverse/triangle/drunk modes on the scale page
* Changes the Teletype clock enables to be the first column of keys on the scale page rather than the first row