### PR TITLE
 triangle forward/reverse state should be per-parameter 

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -347,7 +347,7 @@ void default_kria() {
 	// memset(k.p[0].t[0].pdur, 3, 16);
 	k.p[0].t[0].dur_mul = 4;
 	k.p[0].t[0].direction = krDirForward;
-	k.p[0].t[0].advancing = true;
+	memset(k.p[0].t[0].advancing, 1, KRIA_NUM_PARAMS);
 	memset(k.p[0].t[0].lstart, 0, KRIA_NUM_PARAMS);
 	memset(k.p[0].t[0].lend, 5, KRIA_NUM_PARAMS);
 	memset(k.p[0].t[0].llen, 6, KRIA_NUM_PARAMS);
@@ -469,12 +469,12 @@ bool kria_next_step(uint8_t t, uint8_t p) {
 				break;
 			case krDirTriangle:
 				if (pos[t][p] == k.p[k.pattern].t[t].lend[p]) {
-					k.p[k.pattern].t[t].advancing = false;
+					k.p[k.pattern].t[t].advancing[p] = false;
 				}
 				if (pos[t][p] == k.p[k.pattern].t[t].lstart[p]) {
-					k.p[k.pattern].t[t].advancing = true;
+					k.p[k.pattern].t[t].advancing[p] = true;
 				}
-				if (k.p[k.pattern].t[t].advancing) {
+				if (k.p[k.pattern].t[t].advancing[p]) {
 					goto forward;
 				}
 				else {

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -41,7 +41,7 @@ typedef struct {
 
 	u8 dur_mul;
 	kria_direction direction;
-	bool advancing;
+	u8 advancing[KRIA_NUM_PARAMS];
 
 	u8 lstart[KRIA_NUM_PARAMS];
 	u8 lend[KRIA_NUM_PARAMS];


### PR DESCRIPTION
This was causing all parameters to change direction when any parameter reached the end of its loop, reported [here](https://llllllll.co/t/ansible-kria-feature-requests/4846/146?u=csboling). Pushed the state for this down to the parameter level.