### PR TITLE
kria: move tt clock enables to track state

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -91,9 +91,6 @@ softTimer_t repeatTimer[4] = {
 	{ .next = NULL, .prev = NULL }
 };
 
-// manually clocking via teletype
-bool kria_tt_clocked[4];
-
 // MP
 
 mp_data_t m;
@@ -341,12 +338,9 @@ void default_kria() {
 	memset(k.p[0].t[0].dur, 0, 16);
 	memset(k.p[0].t[0].rpt, 1, 16);
 	memset(k.p[0].t[0].p, 3, 16 * KRIA_NUM_PARAMS);
-	// memset(k.p[0].t[0].ptr, 3, 16);
-	// memset(k.p[0].t[0].poct, 3, 16);
-	// memset(k.p[0].t[0].pnote, 3, 16);
-	// memset(k.p[0].t[0].pdur, 3, 16);
 	k.p[0].t[0].dur_mul = 4;
 	k.p[0].t[0].direction = krDirForward;
+	k.p[0].t[0].tt_clocked = false;
 	memset(k.p[0].t[0].advancing, 1, KRIA_NUM_PARAMS);
 	memset(k.p[0].t[0].lstart, 0, KRIA_NUM_PARAMS);
 	memset(k.p[0].t[0].lend, 5, KRIA_NUM_PARAMS);
@@ -568,9 +562,9 @@ void clock_kria(uint8_t phase) {
 		}
 
 
-		for ( uint8_t i=0; i<4; i++ )
+		for ( uint8_t i=0; i<KRIA_NUM_TRACKS; i++ )
 		{
-			if ( !kria_tt_clocked[i] )
+			if ( !k.p[k.pattern].t[i].tt_clocked )
 				clock_kria_track( i );
 		}
 
@@ -1059,12 +1053,12 @@ void ii_kria(uint8_t *d, uint8_t l) {
 		case II_KR_CLK:
 			if ( d[1] == 0 ) {
 				for ( int i=0; i<KRIA_NUM_TRACKS; i++ ) {
-					if ( kria_tt_clocked[i] )
+					if ( k.p[k.pattern].t[i].tt_clocked )
 						clock_kria_track( i );
 				}
 			}
 			else if ( d[1] <= KRIA_NUM_TRACKS && d[1] > 0  ) {
-				if ( kria_tt_clocked[d[1]-1] )
+				if ( k.p[k.pattern].t[d[1]-1].tt_clocked )
 					clock_kria_track( d[1]-1 );
 			}
 		default:
@@ -1722,7 +1716,7 @@ void handler_KriaGridKey(s32 data) {
 					if ( y < 4 && x < 6 ) {
 						// tt clocking stuff added here
 						if ( x == 0){
-							kria_tt_clocked[y] = !kria_tt_clocked[y];
+						        k.p[k.pattern].t[y].tt_clocked = !k.p[k.pattern].t[y].tt_clocked;
 						}
 
 						if (x > 0 && x < 6) {
@@ -2363,7 +2357,7 @@ void refresh_kria_glide(void) {
 void refresh_kria_scale(void) {
 	for ( uint8_t y=0; y<4; y++ ) {
 		// if teletype clocking is enabled, track is brighter
-		monomeLedBuffer[0+16*y] = kria_tt_clocked[y] ? L1 : L0;
+		monomeLedBuffer[0+16*y] = k.p[k.pattern].t[y].tt_clocked ? L1 : L0;
 		for ( uint8_t x=1; x<6; x++ ) {
 			monomeLedBuffer[x+16*y] = k.p[k.pattern].t[y].direction == x - 1 ? L1 : L0;
 		}

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -48,6 +48,8 @@ typedef struct {
 	u8 llen[KRIA_NUM_PARAMS];
 	u8 lswap[KRIA_NUM_PARAMS];
 	u8 tmul[KRIA_NUM_PARAMS];
+
+	bool tt_clocked;
 } kria_track;
 
 typedef struct {


### PR DESCRIPTION
Moves Teletype clock enable settings to `kria_track` so they're saved to flash, [discussion](https://llllllll.co/t/ansible-kria-feature-requests/4846/148).