### PR TITLE
kria: track-wide octave shift and negative octave transposition

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -576,6 +576,10 @@ void clock_kria(uint8_t phase) {
 	}
 }
 
+static inline int8_t sum_clip_octave(int8_t l, int8_t r) {
+	return min(5, max(0, l + r));
+}
+
 void clock_kria_track( uint8_t trackNum ) {
 	u64 current_tick = get_ticks();
 	clock_deltas[trackNum] = (u32)(current_tick-last_ticks[trackNum]);
@@ -591,7 +595,7 @@ void clock_kria_track( uint8_t trackNum ) {
 	}
 
 	if(kria_next_step(trackNum, mOct)) {
-		oct[trackNum] = track->octshift + track->oct[pos[trackNum][mOct]];
+		oct[trackNum] = sum_clip_octave(track->octshift, track->oct[pos[trackNum][mOct]]);
 	}
 
 	if(kria_next_step(trackNum, mNote)) {
@@ -2224,7 +2228,7 @@ void refresh_kria_oct(void) {
 
 		for(uint8_t i=0;i<16;i++) {
 			const uint8_t octshift = k.p[k.pattern].t[track].octshift;
-			const int8_t octsum = min(max(0, k.p[k.pattern].t[track].oct[i] + (int)octshift), 5);
+			const int8_t octsum = sum_clip_octave(k.p[k.pattern].t[track].oct[i], (int)octshift);
 
 			for(uint8_t j=0;j<=5;j++) {
 				if (octsum >= octshift) {

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -338,6 +338,7 @@ void default_kria() {
 	memset(k.p[0].t[0].dur, 0, 16);
 	memset(k.p[0].t[0].rpt, 1, 16);
 	memset(k.p[0].t[0].p, 3, 16 * KRIA_NUM_PARAMS);
+	k.p[0].t[0].octshift = 0;
 	k.p[0].t[0].dur_mul = 4;
 	k.p[0].t[0].direction = krDirForward;
 	k.p[0].t[0].tt_clocked = false;
@@ -590,7 +591,7 @@ void clock_kria_track( uint8_t trackNum ) {
 	}
 
 	if(kria_next_step(trackNum, mOct)) {
-		oct[trackNum] = track->oct[pos[trackNum][mOct]];
+		oct[trackNum] = track->octshift + track->oct[pos[trackNum][mOct]];
 	}
 
 	if(kria_next_step(trackNum, mNote)) {
@@ -1441,8 +1442,15 @@ void handler_KriaGridKey(s32 data) {
 				switch(k_mod_mode) {
 				case modNone:
 					if(z) {
-						if(y>2)
-							k.p[k.pattern].t[track].oct[x] = 6-y;
+						if(y==0) {
+							if (x <= 5) {
+								k.p[k.pattern].t[track].octshift = x;
+							}
+						}
+						else {
+							uint8_t abs_oct = 6 - y;
+							k.p[k.pattern].t[track].oct[x] = (int)abs_oct - (int)k.p[k.pattern].t[track].octshift;
+						}
 						monomeFrameDirty++;
 					}
 					break;
@@ -2211,25 +2219,37 @@ void refresh_kria_oct(void) {
 				monomeLedBuffer[(5 - k.p[k.pattern].t[track].p[mOct][i]) * 16 + i] = 6;
 		break;
 	default:
-		for(uint8_t i=0;i<16;i++) {
-				for(uint8_t j=0;j<=k.p[k.pattern].t[track].oct[i];j++)
-					monomeLedBuffer[R6-16*j+i] = L0;
+		memset(monomeLedBuffer, 2, 6);
+		monomeLedBuffer[R0+k.p[k.pattern].t[track].octshift] = L1;
 
-				if(i == pos[track][mOct])
-					monomeLedBuffer[R6 - k.p[k.pattern].t[track].oct[i]*16 + i] += 4;
+		for(uint8_t i=0;i<16;i++) {
+			const uint8_t octshift = k.p[k.pattern].t[track].octshift;
+			const int8_t octsum = min(max(0, k.p[k.pattern].t[track].oct[i] + (int)octshift), 5);
+
+			for(uint8_t j=0;j<=5;j++) {
+				if (octsum >= octshift) {
+					if (j < octshift || j > octsum) continue;
+				}
+				else {
+					if (j < octsum || j > octshift) continue;
+				}
+				monomeLedBuffer[R6-16*j+i] = L0;
+
+				if(k.p[k.pattern].t[track].lswap[mOct]) {
+					if((i < k.p[k.pattern].t[track].lstart[mOct]) && (i > k.p[k.pattern].t[track].lend[mOct])) {
+						monomeLedBuffer[R6-16*j+i] -= 2;
+					}
+				}
+				else {
+					if((i < k.p[k.pattern].t[track].lstart[mOct]) || (i > k.p[k.pattern].t[track].lend[mOct])) {
+						monomeLedBuffer[R6-16*j+i] -= 2;
+					}
+				}
 			}
 
-		if(k.p[k.pattern].t[track].lswap[mOct]) {
-			for(uint8_t i=0;i<16;i++)
-				if((i < k.p[k.pattern].t[track].lstart[mOct]) && (i > k.p[k.pattern].t[track].lend[mOct]))
-					for(uint8_t j=0;j<=k.p[k.pattern].t[track].oct[i];j++)
-						monomeLedBuffer[R6-16*j+i] -= 2;
-		}
-		else {
-			for(uint8_t i=0;i<16;i++)
-				if((i < k.p[k.pattern].t[track].lstart[mOct]) || (i > k.p[k.pattern].t[track].lend[mOct]))
-					for(uint8_t j=0;j<=k.p[k.pattern].t[track].oct[i];j++)
-						monomeLedBuffer[R6-16*j+i] -= 2;
+			if(i == pos[track][mOct]) {
+				monomeLedBuffer[R6 - octsum*16 + i] += 4;
+			}
 		}
 		break;
 	}

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -25,7 +25,7 @@ typedef enum {
 
 typedef struct {
 	u8 tr[16];
-	u8 oct[16];
+	s8 oct[16];
 	u8 note[16];
 	u8 dur[16];
 	u8 rpt[16];
@@ -42,6 +42,7 @@ typedef struct {
 	u8 dur_mul;
 	kria_direction direction;
 	u8 advancing[KRIA_NUM_PARAMS];
+	u8 octshift;
 
 	u8 lstart[KRIA_NUM_PARAMS];
 	u8 lend[KRIA_NUM_PARAMS];


### PR DESCRIPTION
Fixes #29 

Video [here](https://llllllll.co/t/ansible-kria-feature-requests/4846/173). This adds an octave shift per track on the octave page along the top row. When the octave shift is engaged for a track, the "home row" of the octave page moves up a corresponding number of keys. This allows you to transpose some notes down one or more octaves from the root.

When transposing up a couple octaves, it seemed kind of cramped to have a ceiling on the amount of octave transposition, so in this change all notes have a full 0-5V octave range at all times. One downside of this is that it pretty much uses up the whole octave page. It would be straightforward to impose a lower ceiling than 5V for the maximum octave to get some more UI space back and constrain the pitch CV range.