### PR TITLE
kria: optionally phase sync on time div change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 *.obj
 *.elf
 *.d
+*~
+*#
+.#*
 
 # Precompiled Headers
 *.gch

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -520,20 +520,25 @@ bool kria_next_step(uint8_t t, uint8_t p) {
 				}
 				break;
 			case krDirDrunk:
-				if ((rnd() & 0xff) > 128) {
+				if (rnd() % 2) {
 					goto forward;
 				} else {
 					goto reverse;
 				}
 				break;
-			case krDirRandom:
-				if (k.p[k.pattern].t[t].lend[p] >= k.p[k.pattern].t[t].lstart[p]) {
-					pos[t][p] = k.p[k.pattern].t[t].lstart[p] + rnd() % (k.p[k.pattern].t[t].lend[p] - k.p[k.pattern].t[t].lstart[p]);
+			case krDirRandom: {
+				int8_t lstart = k.p[k.pattern].t[t].lstart[p];
+				uint8_t lend = k.p[k.pattern].t[t].lend[p];
+				uint8_t llen = k.p[k.pattern].t[t].llen[p];
+
+				if (lend >= lstart) {
+					pos[t][p] = lstart + rnd() % (lend - lstart);
 				}
 				else {
-					pos[t][p] = (k.p[k.pattern].t[t].lstart[p] + rnd() % k.p[k.pattern].t[t].llen[p]) % 16;
+					pos[t][p] = (lstart + rnd() % llen) % 16;
 				}
 				break;
+			}
 		}
 
 		switch(k.p[k.pattern].t[t].p[p][pos[t][p]]) {

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -527,7 +527,7 @@ bool kria_next_step(uint8_t t, uint8_t p) {
 				}
 				break;
 			case krDirRandom: {
-				int8_t lstart = k.p[k.pattern].t[t].lstart[p];
+				uint8_t lstart = k.p[k.pattern].t[t].lstart[p];
 				uint8_t lend = k.p[k.pattern].t[t].lend[p];
 				uint8_t llen = k.p[k.pattern].t[t].llen[p];
 

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -70,8 +70,8 @@ typedef struct {
 } kria_data_t;
 
 typedef enum {
-	krSyncNone,
-	krSyncTime,
+	krSyncNone    = 0x00,
+	krSyncTimeDiv = 0x01,
 } kria_sync_mode_t;
 
 typedef struct {

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -69,8 +69,14 @@ typedef struct {
 	uint8_t glyph[8];
 } kria_data_t;
 
+typedef enum {
+	krSyncNone,
+	krSyncTime,
+} kria_sync_mode_t;
+
 typedef struct {
 	uint32_t clock_period;
+	kria_sync_mode_t sync_mode;
 	uint8_t preset;
 	bool note_sync;
 	uint8_t loop_sync;


### PR DESCRIPTION
Fixes #25 

On Kria's config page, adds a toggle below the note sync square for enabling this feature. When enabled, changing a time division for a parameter will take effect only when that parameter's loop reaches its end. Given that step direction is now configurable, this takes effect at the opposite end of the loop when in reverse mode, and at both ends of the loop when in triangle mode. In drunk and random step modes this setting is ignored.