### PR TITLE
kria: some advanced note placement features

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -448,17 +448,17 @@ void grid_keytimer_kria(uint8_t held_key) {
 		break;
 	case mRpt:
 		if(held_key < 16) {
-			k.p[k.pattern].t[track].rpt[held_key] = 5;
-		}
-		if(held_key >= R6 && held_key < R7) {
-			uint8_t x = held_key - R6;
 			uint8_t rpt = 0;
-			uint8_t rptBits = k.p[k.pattern].t[track].rptBits[x];
+			uint8_t rptBits = k.p[k.pattern].t[track].rptBits[held_key];
 			while (rptBits) {
 				rptBits >>= 1;
 				rpt++;
 			}
-			k.p[k.pattern].t[track].rpt[x] = rpt;
+			k.p[k.pattern].t[track].rpt[held_key] = rpt;
+		}
+		else if(held_key >= R6 && held_key < R7) {
+			k.p[k.pattern].t[track].rpt[held_key - R6] = 1;
+			k.p[k.pattern].t[track].rptBits[held_key - R6] = 1;
 		}
 		break;
 	default:

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -344,6 +344,7 @@ void default_kria() {
 	k.p[0].t[0].dur_mul = 4;
 	k.p[0].t[0].direction = krDirForward;
 	k.p[0].t[0].tt_clocked = false;
+	k.p[0].t[0].trigger_steps = false;
 	memset(k.p[0].t[0].advancing, 1, KRIA_NUM_PARAMS);
 	memset(k.p[0].t[0].lstart, 0, KRIA_NUM_PARAMS);
 	memset(k.p[0].t[0].lend, 5, KRIA_NUM_PARAMS);
@@ -1317,29 +1318,22 @@ void handler_KriaGridKey(s32 data) {
 		if(z) {
 			if(x<8 && y<7) {
 				note_sync ^= 1;
-				if(loop_sync == 0)
-					loop_sync = 1;
 				flashc_memset8((void*)&(f.kria_state.note_sync), note_sync, 1, true);
-				flashc_memset8((void*)&(f.kria_state.loop_sync), loop_sync, 1, true);
 			}
 			else if(y == 3) {
 				if(loop_sync == 1) {
 					loop_sync = 0;
-					note_sync = 0;
 				}
 				else loop_sync = 1;
 
-				flashc_memset8((void*)&(f.kria_state.note_sync), note_sync, 1, true);
 				flashc_memset8((void*)&(f.kria_state.loop_sync), loop_sync, 1, true);
 			}
 			else if(y == 5) {
 				if(loop_sync == 2) {
 					loop_sync = 0;
-					note_sync = 0;
 				}
 				else loop_sync = 2;
 
-				flashc_memset8((void*)&(f.kria_state.note_sync), note_sync, 1, true);
 				flashc_memset8((void*)&(f.kria_state.loop_sync), loop_sync, 1, true);
 			}
 			else if (y == 7) {
@@ -1450,6 +1444,10 @@ void handler_KriaGridKey(s32 data) {
 							loop_last = x;
 							update_loop_start(loop_edit, loop_first, mTr);
 							update_loop_end(loop_edit, loop_last, mTr);
+							if (note_sync) {
+								update_loop_start(loop_edit, loop_first, mNote);
+								update_loop_end(loop_edit, loop_last, mNote);
+							}
 						}
 
 						loop_count++;
@@ -1459,12 +1457,13 @@ void handler_KriaGridKey(s32 data) {
 
 						if(loop_count == 0) {
 							if(loop_last == -1) {
+								update_loop_start(loop_edit, loop_first, mTr);
 								if(loop_first == k.p[k.pattern].t[loop_edit].lstart[mTr]) {
-									update_loop_start(loop_edit, loop_first, mTr);
 									update_loop_end(loop_edit, loop_first, mTr);
+									if (note_sync) {
+										update_loop_end(loop_edit, loop_first, mNote);
+									}
 								}
-								else
-									update_loop_start(loop_edit, loop_first, mTr);
 							}
 							monomeFrameDirty++;
 						}
@@ -1513,6 +1512,10 @@ void handler_KriaGridKey(s32 data) {
 							loop_last = x;
 							update_loop_start(track, loop_first, mNote);
 							update_loop_end(track, loop_last, mNote);
+							if (note_sync) {
+								update_loop_start(track, loop_first, mTr);
+								update_loop_end(track, loop_last, mTr);
+							}
 						}
 
 						loop_count++;
@@ -1522,12 +1525,16 @@ void handler_KriaGridKey(s32 data) {
 
 						if(loop_count == 0) {
 							if(loop_last == -1) {
-								if(loop_first == k.p[k.pattern].t[track].lstart[mNote]) {
-									update_loop_start(track, loop_first, mNote);
-									update_loop_end(track, loop_first, mNote);
+								update_loop_start(track, loop_first, mNote);
+								if (note_sync) {
+									update_loop_start(track, loop_first, mTr);
 								}
-								else
-									update_loop_start(track, loop_first, mNote);
+								if(loop_first == k.p[k.pattern].t[track].lstart[mNote]) {
+									update_loop_end(track, loop_first, mNote);
+									if (note_sync) {
+										update_loop_end(track, loop_first, mTr);
+									}
+								}
 							}
 							monomeFrameDirty++;
 						}

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -2403,7 +2403,7 @@ void refresh_kria_rpt(void) {
 				}
 			}
 			if ( i == pos[track][mRpt]) {
-				uint8_t y = activeRpt[track] - repeats[track];
+				uint8_t y = max(1, activeRpt[track] - repeats[track]);
 				monomeLedBuffer[R6 - y*16 + i] += (rptBits & (1 << y)) ? 4 : 2;
 			}
 			monomeLedBuffer[i] = 1;

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -337,6 +337,7 @@ void default_kria() {
 	memset(k.p[0].t[0].note, 0, 16);
 	memset(k.p[0].t[0].dur, 0, 16);
 	memset(k.p[0].t[0].rpt, 1, 16);
+	memset(k.p[0].t[0].rptBits, 1, 16);
 	memset(k.p[0].t[0].p, 3, 16 * KRIA_NUM_PARAMS);
 	k.p[0].t[0].dur_mul = 4;
 	k.p[0].t[0].direction = krDirForward;
@@ -598,7 +599,7 @@ void clock_kria_track( uint8_t trackNum ) {
 	}
 
 	if(kria_next_step(trackNum, mRpt)) {
-		rpt[trackNum] = track->rpt[pos[trackNum][mRpt]] & 0xF;
+		rpt[trackNum] = track->rpt[pos[trackNum][mRpt]];
 	}
 	if(kria_next_step(trackNum, mAltNote)) {
 		alt_note[trackNum] = track->alt_note[pos[trackNum][mAltNote]];
@@ -624,7 +625,7 @@ void clock_kria_track( uint8_t trackNum ) {
 				timer_add( &repeatTimer[trackNum], rptTicks[trackNum], &kria_rpt_off, trackIndex );
 			}
 
-			if ( (track->rpt[pos[trackNum][mRpt]] >> 4) & 1 ) {
+			if ( track->rptBits[pos[trackNum][mRpt]] & 1 ) {
 				set_tr( TR1 + trackNum );
 
 				timer_remove( &auxTimer[trackNum]);
@@ -662,7 +663,7 @@ static void kria_rpt_off(void* o) {
 		timer_remove( &repeatTimer[index] );
 	}
 
-	if ( (k.p[k.pattern].t[index].rpt[pos[index][mRpt]] >> 4) & ( 1 << bit ) ) {
+	if ( k.p[k.pattern].t[index].rptBits[pos[index][mRpt]] & ( 1 << bit ) ) {
 		set_tr( TR1 + index );
 		tr[index] = 1;
 		kria_blinks[index] = 1;
@@ -1557,10 +1558,11 @@ void handler_KriaGridKey(s32 data) {
 				case modNone:
 					if (z) {
 						if ( y > 1 && y < 6 ) {
-					  		uint8_t rptBits = (k.p[k.pattern].t[track].rpt[x] >> 4) ^ (1 << (5 - y));
+					  		uint8_t rptBits = k.p[k.pattern].t[track].rptBits[x] ^ (1 << (5 - y));
 							uint8_t rpt = 1;
+							k.p[k.pattern].t[track].rptBits[x] = rptBits;
 							while (rptBits >>= 1) rpt++;
-							k.p[k.pattern].t[track].rpt[x] = rpt | (rptBits << 4);
+							k.p[k.pattern].t[track].rpt[x] = rpt;
 
 							monomeFrameDirty++;
 						}
@@ -2295,7 +2297,7 @@ void refresh_kria_rpt(void) {
 		break;
 	default:
 		for ( uint8_t i=0; i<16; i++ ) {
-			uint8_t rptBits = k.p[k.pattern].t[track].rpt[i] >> 4;
+			uint8_t rptBits = k.p[k.pattern].t[track].rptBits[i];
 			for ( uint8_t j=0; j<4; j++) {
 				uint8_t led = 16*(5-j) + i;
 				monomeLedBuffer[led] = 0;

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -1854,7 +1854,7 @@ void handler_KriaGridKey(s32 data) {
 				break;
 			case mScale:
 				if(z) {
-					if ( y < 4 && x < 6 ) {
+					if ( y < 4 && x <= 7 ) {
 						if (x == 0){
 						        k.p[k.pattern].t[y].tt_clocked = !k.p[k.pattern].t[y].tt_clocked;
 						}
@@ -2542,7 +2542,7 @@ void refresh_kria_scale(void) {
 
 		// show selected direction
 		for ( uint8_t x=3; x<=7; x++ ) {
-			monomeLedBuffer[x+16*y] = k.p[k.pattern].t[y].direction == x - 3 ? 5 : 3;
+			monomeLedBuffer[x+16*y] = (k.p[k.pattern].t[y].direction == (x - 3)) ? 4 : 2;
 		}
 	}
 

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -52,7 +52,7 @@ typedef struct {
 	u8 tmul[KRIA_NUM_PARAMS];
 
 	bool tt_clocked;
-	bool trigger_steps;
+	bool trigger_clocked;
 } kria_track;
 
 typedef struct {

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -29,7 +29,6 @@ typedef struct {
 	u8 note[16];
 	u8 dur[16];
 	u8 rpt[16];
-	u8 rptBits[16];
 	u8 alt_note[16];
 	u8 glide[16];
 

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -29,6 +29,7 @@ typedef struct {
 	u8 note[16];
 	u8 dur[16];
 	u8 rpt[16];
+	u8 rptBits[16];
 	u8 alt_note[16];
 	u8 glide[16];
 

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -52,6 +52,7 @@ typedef struct {
 	u8 tmul[KRIA_NUM_PARAMS];
 
 	bool tt_clocked;
+	bool trigger_steps;
 } kria_track;
 
 typedef struct {
@@ -137,6 +138,7 @@ void init_kria(void);
 void resume_kria(void);
 void clock_kria(uint8_t phase);
 void clock_kria_track( uint8_t trackNum );
+void clock_kria_note(kria_track* track, uint8_t trackNum);
 void ii_kria(uint8_t *d, uint8_t l);
 void handler_KriaGridKey(s32 data);
 void handler_KriaRefresh(s32 data);

--- a/src/ansible_preset_docdef.c
+++ b/src/ansible_preset_docdef.c
@@ -264,7 +264,7 @@ json_docdef_t ansible_app_docdefs[] = {
 																	.write = json_write_object,
 																	.state = &ansible_app_object_state[3],
 																	.params = &((json_read_object_params_t) {
-																		.docdef_ct = 17,
+																		.docdef_ct = 18,
 																		.docdefs = ((json_docdef_t[]) {
 																			{
 																				.name = "tr",
@@ -440,6 +440,15 @@ json_docdef_t ansible_app_docdefs[] = {
 																				.params = &((json_read_scalar_params_t) {
 																					.dst_size = sizeof_field(nvram_data_t, kria_state.k[0].p[0].t[0].tt_clocked),
 																					.dst_offset = offsetof(nvram_data_t, kria_state.k[0].p[0].t[0].tt_clocked),
+																				}),
+																			},
+																			{
+																				.name = "trigger_steps",
+																				.read = json_read_scalar,
+																				.write = json_write_bool,
+																				.params = &((json_read_scalar_params_t) {
+																					.dst_size = sizeof_field(nvram_data_t, kria_state.k[0].p[0].t[0].trigger_steps),
+																					.dst_offset = offsetof(nvram_data_t, kria_state.k[0].p[0].t[0].trigger_steps),
 																				}),
 																			},
 																		}),

--- a/src/ansible_preset_docdef.c
+++ b/src/ansible_preset_docdef.c
@@ -264,7 +264,7 @@ json_docdef_t ansible_app_docdefs[] = {
 																	.write = json_write_object,
 																	.state = &ansible_app_object_state[3],
 																	.params = &((json_read_object_params_t) {
-																		.docdef_ct = 19,
+																		.docdef_ct = 20,
 																		.docdefs = ((json_docdef_t[]) {
 																			{
 																				.name = "tr",
@@ -314,6 +314,16 @@ json_docdef_t ansible_app_docdefs[] = {
 																				.params = &((json_read_buffer_params_t) {
 																					.dst_size = sizeof_field(nvram_data_t, kria_state.k[0].p[0].t[0].rpt),
 																					.dst_offset = offsetof(nvram_data_t, kria_state.k[0].p[0].t[0].rpt),
+																				}),
+																			},
+																			{
+																				.name = "rptBits",
+																				.read = json_read_buffer,
+																				.write = json_write_buffer,
+																				.state = &ansible_json_read_buffer_state,
+																				.params = &((json_read_buffer_params_t) {
+																					.dst_size = sizeof_field(nvram_data_t, kria_state.k[0].p[0].t[0].rptBits),
+																					.dst_offset = offsetof(nvram_data_t, kria_state.k[0].p[0].t[0].rptBits),
 																				}),
 																			},
 																			{

--- a/src/ansible_preset_docdef.c
+++ b/src/ansible_preset_docdef.c
@@ -264,7 +264,7 @@ json_docdef_t ansible_app_docdefs[] = {
 																	.write = json_write_object,
 																	.state = &ansible_app_object_state[3],
 																	.params = &((json_read_object_params_t) {
-																		.docdef_ct = 18,
+																		.docdef_ct = 19,
 																		.docdefs = ((json_docdef_t[]) {
 																			{
 																				.name = "tr",
@@ -443,12 +443,12 @@ json_docdef_t ansible_app_docdefs[] = {
 																				}),
 																			},
 																			{
-																				.name = "trigger_steps",
+																				.name = "trigger_clocked",
 																				.read = json_read_scalar,
 																				.write = json_write_bool,
 																				.params = &((json_read_scalar_params_t) {
-																					.dst_size = sizeof_field(nvram_data_t, kria_state.k[0].p[0].t[0].trigger_steps),
-																					.dst_offset = offsetof(nvram_data_t, kria_state.k[0].p[0].t[0].trigger_steps),
+																					.dst_size = sizeof_field(nvram_data_t, kria_state.k[0].p[0].t[0].trigger_clocked),
+																					.dst_offset = offsetof(nvram_data_t, kria_state.k[0].p[0].t[0].trigger_clocked),
 																				}),
 																			},
 																		}),


### PR DESCRIPTION
Binaries + videos [here](https://llllllll.co/t/ansible-development-and-beta-firmware-discussion/23118).

* Ability to toggle individual gates off and on within each note on the ratchet page
* Ability to select number of subdivisions on the ratchet page, so you can e.g. have rests at the end of a note step, using row 0 (top row) and row 6 on the ratchet page. Number of subdivisions is automatically set when you enable a gate. Long pressing row 6 will clear the ratchet settings, so only a single note is played without being subdivided. Long pressing row 0 will set the subdivision count equal to the latest gate you have selected, so that there are no rests at the end of the step.
* [Trigger clocking](https://llllllll.co/t/kria-feature-trigger-step-params/14501), concept and original code by @AaronMeyers, enabled per-track by additional toggles on the scale page. In this mode parameters other than trigger and ratchet only advance when a trigger occurs. Moved over the direction mode keys and changed their brightness a little to make them more visually distinct from trigger clock/TT clock enable keys.
* Ability to keep note sync on when loop sync is off, in which case the loop boundaries for trigger and note are updated together but all other parameters are independent.