### PR TITLE
Support for new TT remote ops

### DIFF
--- a/src/ansible_arc.c
+++ b/src/ansible_arc.c
@@ -24,7 +24,8 @@ static int16_t enc_count[4];
 
 void (*arc_refresh)(void);
 
-static void ii_arc_simulate_enc(uint8_t* data, uint8_t len);
+static void ii_arc_simulate_enc(uint8_t* d, uint8_t len);
+static void ii_arc_read_led(uint8_t* d, uint8_t len);
 
 ////////////////////////////////////////////////////////////////////////////////
 // LEVELS
@@ -308,6 +309,16 @@ static void ii_arc_simulate_enc(uint8_t* d, uint8_t len) {
 		e.type = kEventMonomeRingEnc;
 		event_post(&e);
 	}
+}
+
+static void ii_arc_read_led(uint8_t* d, uint8_t len) {
+	u8 led = 0;
+	if (len >= 2
+	  && d[0] < 4
+	  && d[1] < 64) {
+		led = monomeLedBuffer[d[0] * 64 + d[1]];
+	}
+	ii_tx_queue(led);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -644,6 +655,9 @@ void ii_levels(uint8_t *d, uint8_t len) {
 			break;
 		case II_ARC_ENC:
 			ii_arc_simulate_enc(d, len);
+			break;
+		case II_ARC_LED + II_GET:
+			ii_arc_read_led(d, len);
 			break;
 		default:
 			break;
@@ -1517,6 +1531,9 @@ void ii_cycles(uint8_t *d, uint8_t len) {
 			break;
 		case II_ARC_ENC:
 			ii_arc_simulate_enc(d, len);
+			break;
+		case II_ARC_LED + II_GET:
+			ii_arc_read_led(d, len);
 			break;
 		default:
 			break;

--- a/src/ansible_arc.c
+++ b/src/ansible_arc.c
@@ -24,7 +24,7 @@ static int16_t enc_count[4];
 
 void (*arc_refresh)(void);
 
-
+static void ii_arc_simulate_enc(uint8_t* data, uint8_t len);
 
 ////////////////////////////////////////////////////////////////////////////////
 // LEVELS
@@ -298,8 +298,17 @@ void refresh_arc_preset(void) {
 	}
 }
 
-
-
+static void ii_arc_simulate_enc(uint8_t* d, uint8_t len) {
+	if (len >= 2
+	 && d[0] < 4) {
+		event_t e;
+		u8* data = (u8*)(&(e.data));
+		data[0] = d[0];
+		data[1] = d[1];
+		e.type = kEventMonomeRingEnc;
+		event_post(&e);
+	}
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -632,6 +641,9 @@ void ii_levels(uint8_t *d, uint8_t len) {
 			}
 			ii_tx_queue(dac_get_value(d[1]) >> 8);
 			ii_tx_queue(dac_get_value(d[1]) & 0xff);
+			break;
+		case II_ARC_ENC:
+			ii_arc_simulate_enc(d, len);
 			break;
 		default:
 			break;
@@ -1502,6 +1514,9 @@ void ii_cycles(uint8_t *d, uint8_t len) {
 			}
 			ii_tx_queue(dac_get_value(d[1]) >> 8);
 			ii_tx_queue(dac_get_value(d[1]) & 0xff);
+			break;
+		case II_ARC_ENC:
+			ii_arc_simulate_enc(d, len);
 			break;
 		default:
 			break;

--- a/src/ansible_arc.c
+++ b/src/ansible_arc.c
@@ -24,9 +24,6 @@ static int16_t enc_count[4];
 
 void (*arc_refresh)(void);
 
-static void ii_arc_simulate_enc(uint8_t* d, uint8_t len);
-static void ii_arc_read_led(uint8_t* d, uint8_t len);
-
 ////////////////////////////////////////////////////////////////////////////////
 // LEVELS
 
@@ -297,28 +294,6 @@ void refresh_arc_preset(void) {
 		monomeLedBuffer[arc_preset * 8 + i1] = 7;
 		monomeLedBuffer[arc_preset_select * 8 + i1] = 15;
 	}
-}
-
-static void ii_arc_simulate_enc(uint8_t* d, uint8_t len) {
-	if (len >= 2
-	 && d[0] < 4) {
-		event_t e;
-		u8* data = (u8*)(&(e.data));
-		data[0] = d[0];
-		data[1] = d[1];
-		e.type = kEventMonomeRingEnc;
-		event_post(&e);
-	}
-}
-
-static void ii_arc_read_led(uint8_t* d, uint8_t len) {
-	u8 led = 0;
-	if (len >= 2
-	  && d[0] < 4
-	  && d[1] < 64) {
-		led = monomeLedBuffer[d[0] * 64 + d[1]];
-	}
-	ii_tx_queue(led);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -653,13 +628,8 @@ void ii_levels(uint8_t *d, uint8_t len) {
 			ii_tx_queue(dac_get_value(d[1]) >> 8);
 			ii_tx_queue(dac_get_value(d[1]) & 0xff);
 			break;
-		case II_ARC_ENC:
-			ii_arc_simulate_enc(d, len);
-			break;
-		case II_ARC_LED + II_GET:
-			ii_arc_read_led(d, len);
-			break;
 		default:
+			ii_ansible(d, len);
 			break;
 		}
 	}
@@ -1529,13 +1499,8 @@ void ii_cycles(uint8_t *d, uint8_t len) {
 			ii_tx_queue(dac_get_value(d[1]) >> 8);
 			ii_tx_queue(dac_get_value(d[1]) & 0xff);
 			break;
-		case II_ARC_ENC:
-			ii_arc_simulate_enc(d, len);
-			break;
-		case II_ARC_LED + II_GET:
-			ii_arc_read_led(d, len);
-			break;
 		default:
+			ii_ansible(d, len);
 			break;
 		}
 	}

--- a/src/ansible_arc.h
+++ b/src/ansible_arc.h
@@ -52,6 +52,7 @@ void arc_keytimer(void);
 void refresh_arc_preset(void);
 void handler_ArcPresetEnc(s32 data);
 void handler_ArcPresetKey(s32 data);
+void ii_arc(uint8_t* data, uint8_t len);
 
 void default_levels(void);
 void init_levels(void);

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -266,11 +266,8 @@ void grid_keytimer(void) {
 static void ii_grid_simulate_key(uint8_t* d, uint8_t len) {
 	if ( !preset_mode
 	  && len >= 4
-	  && d[1] >= 0
 	  && d[1] < 16
-	  && d[2] >= 0
 	  && d[2] <  8
-	  && d[3] >= 0
 	  && d[3] < 16 ) {
 		event_t e;
 		u8* data = (u8*)(&(e.data));
@@ -286,9 +283,7 @@ static void ii_grid_simulate_key(uint8_t* d, uint8_t len) {
 static void ii_grid_read_led(uint8_t* d, uint8_t len) {
 	u8 led = 0;
 	if ( len >= 3
-	  && d[1] >= 0
 	  && d[1] < 16
-	  && d[2] >= 0
 	  && d[2] < 8 ) {
 		led = monomeLedBuffer[d[2] * 16 + d[1]];
 	}

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -1011,6 +1011,34 @@ void ii_kria(uint8_t *d, uint8_t l) {
 				if ( kria_tt_clocked[d[1]-1] )
 					clock_kria_track( d[1]-1 );
 			}
+			break;
+		case II_GRID:
+			if ( !preset_mode
+			  && d[1] >= 0
+			  && d[1] < 16
+			  && d[2] >= 0
+			  && d[2] <  8
+			  && d[3] >= 0
+			  && d[3] < 16 ) {
+				event_t e;
+				u8* data = (u8*)(&(e.data));
+				e.type = kEventMonomeGridKey;
+				data[0] = d[1];
+				data[1] = d[2];
+				data[2] = d[3];
+				event_post(&e);
+			}
+			break;
+		case II_GRID + II_GET: ;
+			u8 led = 0;
+			if ( d[1] >= 0
+			  && d[1] < 16
+			  && d[2] >= 0
+			  && d[2] < 8 ) {
+				led = monomeLedBuffer[d[2] * 16 + d[1]];
+			}
+			ii_tx_queue(led);
+			break;
 		default:
 			break;
 		}

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -724,9 +724,7 @@ void ii_kria(uint8_t *d, uint8_t l) {
 			break;
 		case II_KR_PATTERN:
 			if(d[1] > -1 && d[1] < 16) {
-				k.pattern = d[1];
-				pos_reset = true;
-				calc_scale(k.p[k.pattern].scale);
+				change_pattern(d[1]);
 			}
 			break;
 		case II_KR_PATTERN + II_GET:
@@ -1092,6 +1090,17 @@ void ii_kria(uint8_t *d, uint8_t l) {
 		case II_KR_PAGE + II_GET:
 			ii_tx_queue(ii_kr_cmd_for_mode(k_mode));
 			break;
+		case II_KR_CUE:
+			if (!meta
+			 && l >= 2) {
+				cue_pat_next = d[1] + 1;
+				cue = true;
+			}
+			break;
+		case II_KR_CUE + II_GET: {
+			ii_tx_queue(cue_pat_next - 1);
+			break;
+		}
 		default:
 			ii_grid(d, l);
 			ii_ansible(d, l);

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -296,7 +296,7 @@ void grid_keytimer(void) {
 					case mGridES:
 						flashc_memset8((void*)&(f.es_state.preset), preset, 1, true);
 						flashc_memcpy((void *)&f.es_state.e[preset], &e, sizeof(e), true);
-                        flashc_memcpy((void *)&f.scale, &scale_data, sizeof(scale_data), true);
+						flashc_memcpy((void *)&f.scale, &scale_data, sizeof(scale_data), true);
 
 						preset_mode = false;
 						grid_refresh = &refresh_es;
@@ -598,7 +598,7 @@ bool kria_next_step(uint8_t t, uint8_t p) {
 	pos_mul[t][p]++;
 
 	bool latch_input = false;
-        if (kria_sync_mode == krSyncNone) {
+	if (kria_sync_mode == krSyncNone) {
 		latch_input = true;
 	}
 	else {
@@ -5052,5 +5052,9 @@ void ii_es(uint8_t *data, uint8_t l) {
             }
             monomeFrameDirty++;
             break;
+
+        default:
+	    ii_grid(data, l);
+	    ii_ansible(data, l);
     }
 }

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -107,6 +107,7 @@ void handler_GridFrontShort(s32 data);
 void handler_GridFrontLong(s32 data);
 void refresh_preset(void);
 void grid_keytimer(void);
+void ii_grid(uint8_t* data, uint8_t len);
 
 void default_kria(void);
 void init_kria(void);

--- a/src/ansible_midi.c
+++ b/src/ansible_midi.c
@@ -262,7 +262,7 @@ void set_mode_midi(void) {
 	default:
 		break;
 	}
-	
+
 	if(connected == conMIDI) {
 		app_event_handlers[kEventFrontShort] = &handler_MidiFrontShort;
 		app_event_handlers[kEventFrontLong] = &handler_MidiFrontLong;
@@ -577,14 +577,13 @@ void ii_midi_standard(uint8_t *d, uint8_t l) {
 			break;
 
 		default:
-			print_dbg("\r\nmid ii; unknown command: ");
-			print_dbg_ulong(d[0]);
+			ii_ansible(d, l);
 			break;
 		}
 	}
 }
 
-void handler_StandardKey(s32 data) { 
+void handler_StandardKey(s32 data) {
 	switch (data) {
 
 	case 0: // key 1 release
@@ -639,7 +638,7 @@ void handler_StandardKey(s32 data) {
 void handler_StandardTr(s32 data) {
 }
 
-void handler_StandardTrNormal(s32 data) { 
+void handler_StandardTrNormal(s32 data) {
 	key_state.normaled = data;
 }
 
@@ -746,7 +745,7 @@ static void mono_note_on(u8 ch, u8 num, u8 vel) {
 
 static void mono_note_off(u8 ch, u8 num, u8 vel) {
 	const held_note_t *prior;
-	
+
 	if (num > MIDI_NOTE_MAX)
 		return;
 
@@ -1107,7 +1106,7 @@ static void fixed_note_off(u8 ch, u8 num, u8 vel) {
 
 static void fixed_control_change(u8 ch, u8 num, u8 val) {
 	static bool initial_set = false;
-	
+
 	if (fixed_learn.learning) {
 		if (fixed_learn.cc_idx < 4) {
 			// initial state; first num always sets first channel
@@ -1247,7 +1246,7 @@ static void arp_clock_pulse(uint8_t phase) {
 	for (u8 i = 0; i < 4; i++) {
 		arp_player_pulse(&(player[i]), active_seq, &player_behavior, phase);
 	}
-	
+
 	// NB: forcing a dac update so that when there is no slewing cv
 	// changes ~30us after the tr goes high. without this cv change is
 	// delayed ~1ms or more based on the update timer freq. that said
@@ -1283,7 +1282,7 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 			arp_state.style = p1;
 			arp_rebuild(&chord);
 			break;
-			
+
 		case II_ARP_HOLD:
 			// print_dbg("\r\narp ii hold: ");
 			// print_dbg_ulong(d[1]);
@@ -1295,7 +1294,7 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 			v = uclip(d[1], 0, 4);
 			p1 = uclip(d[2], 0, 8);
 			s = sclip((int16_t)((d[3] << 8) + d[4]), -24, 24);
-			
+
 			// print_dbg("\r\narp ii rpt: ");
 			// print_dbg_ulong(v);
 			// print_dbg(" ");
@@ -1313,7 +1312,7 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 				arp_player_set_offset(&(player[v-1]), s);
 			}
 			break;
-			
+
 		case II_ARP_GATE:
 			v = uclip(d[1], 0, 4);
 			p1 = uclip(d[2], 0, 127);
@@ -1471,14 +1470,13 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 			break;
 
 		default:
-			print_dbg("\r\narp ii; unknown command: ");
-			print_dbg_ulong(d[0]);
+			ii_ansible(d, l);
 			break;
 		}
 	}
 }
 
-void handler_ArpKey(s32 data) { 
+void handler_ArpKey(s32 data) {
 	static bool tapped = false;
 	u32 now;
 
@@ -1562,7 +1560,7 @@ void handler_ArpTr(s32 data) {
 	}
 }
 
-void handler_ArpTrNormal(s32 data) { 
+void handler_ArpTrNormal(s32 data) {
 	print_dbg("\r\n> arp tr normal ");
 	print_dbg_ulong(data);
 
@@ -1598,7 +1596,7 @@ void restore_midi_arp(void) {
 	// ensure style matches stored config
 	arp_seq_build(active_seq, arp_state.style, &chord, &(notes[0]));
 	arp_seq_build(next_seq, arp_state.style, &chord, &(notes[0]));
-	
+
 	for (u8 i = 0; i < 4; i++) {
 		p = &(player[i]);
 		arp_player_init(p, i, arp_state.p[i].division);
@@ -1653,7 +1651,7 @@ static void arp_state_set_hold(bool hold) {
 
 static void arp_rebuild(chord_t *c) {
 	arp_seq_state current_state = arp_seq_get_state(next_seq);
-	
+
 	if (current_state == eSeqFree || current_state == eSeqWaiting) {
 		arp_seq_set_state(next_seq, eSeqBuilding); // TODO: check return
 		arp_seq_build(next_seq, arp_state.style, &chord, &(notes[0]));

--- a/src/ansible_tt.c
+++ b/src/ansible_tt.c
@@ -104,7 +104,7 @@ void ii_tt(uint8_t *d, uint8_t l) {
 	if(l) {
 		switch(d[0]) {
 		case II_ANSIBLE_TR:
-			if(d[2]) 
+			if(d[2])
 				set_tr(TR1 + d[1]);
 			else
 				clr_tr(TR1 + d[1]);
@@ -183,13 +183,15 @@ void ii_tt(uint8_t *d, uint8_t l) {
 		case II_ANSIBLE_INPUT + II_GET:
 			ii_tx_queue(input[d[1]]);
 			break;
-		default: break;
+		default:
+			ii_ansible(d, l);
+			break;
 		}
 	}
 }
 
 
-void handler_TTKey(s32 data) { 
+void handler_TTKey(s32 data) {
 	// print_dbg("\r\n> TT key");
 	// print_dbg_ulong(data);
 
@@ -212,7 +214,7 @@ void handler_TTKey(s32 data) {
 
 }
 
-void handler_TTTr(s32 data) { 
+void handler_TTTr(s32 data) {
 	// print_dbg("\r\n> TT tr");
 	// print_dbg_ulong(data);
 
@@ -234,7 +236,7 @@ void handler_TTTr(s32 data) {
 	}
 }
 
-void handler_TTTrNormal(s32 data) { 
+void handler_TTTrNormal(s32 data) {
 	// print_dbg("\r\n> TT tr normal ");
 	// print_dbg_ulong(data);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -540,9 +540,10 @@ static ansible_mode_t ii_ansible_mode_for_cmd(uint8_t cmd) {
 	case 1:  return mArcCycles;
         case 2:  return mGridKria;
 	case 3:  return mGridMP;
-	case 4:  return mMidiStandard;
-	case 5:  return mMidiArp;
-	case 6:  return mTT;
+	case 4:  return mGridES;
+	case 5:  return mMidiStandard;
+	case 6:  return mMidiArp;
+	case 7:  return mTT;
 	default: return -1;
 	}
 }
@@ -553,9 +554,10 @@ static uint8_t ii_ansible_cmd_for_mode(ansible_mode_t mode) {
 	case mArcCycles:    return 1;
         case mGridKria:     return 2;
 	case mGridMP:       return 3;
-	case mMidiStandard: return 4;
-	case mMidiArp:      return 5;
-	case mTT:           return 6;
+	case mGridES:       return 4;
+	case mMidiStandard: return 5;
+	case mMidiArp:      return 6;
+	case mTT:           return 7;
 	default:            return -1;
 	}
 }

--- a/src/main.c
+++ b/src/main.c
@@ -531,28 +531,17 @@ void ii_ansible(uint8_t* d, uint8_t len) {
 			ansible_mode_t prev_mode = ansible_mode;
 			ansible_mode_t next_mode = ii_ansible_mode_for_cmd(d[1]);
 
-			// print_dbg("\r\n> prev app: ");
-			// print_dbg_ulong(prev_mode);
-			// print_dbg("\r\n> next app: ");
-			// print_dbg_ulong(next_mode);
-
 			if (next_mode < 0) {
 				break;
 			}
-			// send response before switching because
-			// initialization can take a while
-			uint8_t response = ii_ansible_cmd_for_mode(prev_mode);
-
-			// print_dbg("\r\n> response: ");
-			// print_dbg_ulong(response);
-
-			ii_tx_queue(response);
 			set_mode(next_mode);
 		}
 		break;
-	case II_ANSIBLE_APP + II_GET:
-		ii_tx_queue(ii_ansible_cmd_for_mode(ansible_mode));
+	case II_ANSIBLE_APP + II_GET: {
+		uint8_t cmd = ii_ansible_cmd_for_mode(ansible_mode);
+		ii_tx_queue(cmd);
 		break;
+	}
 	default:
 		break;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -480,57 +480,9 @@ void ii_ansible(uint8_t* d, uint8_t len) {
 	}
 
 	switch (d[0]) {
-	case II_GRID_KEY:
-		if ( !preset_mode
-		  && len >= 4
-		  && d[1] < 16
-		  && d[2] <  8
-		  && d[3] < 16 ) {
-			event_t e;
-			uint8_t* data = (uint8_t*)(&(e.data));
-			e.type = kEventMonomeGridKey;
-			data[0] = d[1];
-			data[1] = d[2];
-			data[2] = d[3];
-			event_post(&e);
-		}
-		break;
-	case II_GRID_LED + II_GET: {
-		uint8_t led = 0;
-		if ( len >= 3
-		  && d[1] < 16
-		  && d[2] < 8 ) {
-			led = monomeLedBuffer[d[2] * 16 + d[1]];
-		}
-		ii_tx_queue(led);
-		break;
-	}
-	case II_ARC_ENC:
-		if (len >= 2
-		 && d[0] < 4) {
-			event_t e;
-			uint8_t* data = (uint8_t*)(&(e.data));
-			data[0] = d[0];
-			data[1] = d[1];
-			e.type = kEventMonomeRingEnc;
-			event_post(&e);
-		}
-		break;
-	case II_ARC_LED + II_GET: {
-		uint8_t led = 0;
-		if ( len >= 2
-		  && d[0] < 4
-		  && d[1] < 64) {
-			led = monomeLedBuffer[d[0] * 64 + d[1]];
-		}
-		ii_tx_queue(led);
-		break;
-	}
 	case II_ANSIBLE_APP:
 		if ( len >= 2 ) {
-			ansible_mode_t prev_mode = ansible_mode;
 			ansible_mode_t next_mode = ii_ansible_mode_for_cmd(d[1]);
-
 			if (next_mode < 0) {
 				break;
 			}

--- a/src/main.h
+++ b/src/main.h
@@ -76,3 +76,5 @@ void clr_tr(uint8_t n);
 uint8_t get_tr(uint8_t n);
 void clock_set(uint32_t n);
 void clock_set_tr(uint32_t n, uint8_t phase);
+
+void ii_ansible(uint8_t* d, uint8_t len);


### PR DESCRIPTION
* Restructures the "null" i2c handler a little bit so that it can support messages that affect the whole module. Other `ii_` functions call this `ii_ansible` handler as a fallback if they don't understand a message.
* Adds Ansible support for the following TT remote ops: `ANS.G`, `ANS.G.P`, `ANS.G.LED`, `ANS.A`, `ANS.A.LED`, `ANS.APP`, `KR.CUE`, `KR.PG`. These allow i2c messages to simulate a grid or arc event, i.e. post an event to the event queue as though a grid key were pressed or an arc ring were rotated, as well as getting/setting the active app remotely.
* Fixes #35 via `KR.CUE` implementation.