### PR TITLE
kria: share div changes across all, track, or trig+note

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -1394,19 +1394,49 @@ static void kria_set_alt_blink_timer(kria_modes_t mode) {
 static void kria_set_tmul(uint8_t track, kria_modes_t mode, uint8_t new_tmul) {
 	switch (div_sync) {
 	case 1:
-		for (uint8_t i = 0; i < KRIA_NUM_PARAMS; i++) {
-			k.p[k.pattern].t[track].tmul[i] = new_tmul;
+		if (note_div_sync) {
+			if (mode == mTr || mode == mRpt) {
+				k.p[k.pattern].t[track].tmul[mTr] = new_tmul;
+				k.p[k.pattern].t[track].tmul[mNote] = new_tmul;
+			} else {
+				k.p[k.pattern].t[track].tmul[mRpt] = new_tmul;
+				k.p[k.pattern].t[track].tmul[mAltNote] = new_tmul;
+				k.p[k.pattern].t[track].tmul[mOct] = new_tmul;
+				k.p[k.pattern].t[track].tmul[mGlide] = new_tmul;
+				k.p[k.pattern].t[track].tmul[mDur] = new_tmul;
+			}
+		} else {
+			k.p[k.pattern].t[track].tmul[mTr] = new_tmul;
+			k.p[k.pattern].t[track].tmul[mNote] = new_tmul;
+			k.p[k.pattern].t[track].tmul[mRpt] = new_tmul;
+			k.p[k.pattern].t[track].tmul[mAltNote] = new_tmul;
+			k.p[k.pattern].t[track].tmul[mOct] = new_tmul;
+			k.p[k.pattern].t[track].tmul[mGlide] = new_tmul;
+			k.p[k.pattern].t[track].tmul[mDur] = new_tmul;
 		}
 		break;
 	case 2:
 		for (uint8_t i = 0; i < 4; i++) {
-			k.p[k.pattern].t[i].tmul[mTr] = new_tmul;
-			k.p[k.pattern].t[i].tmul[mRpt] = new_tmul;
-			k.p[k.pattern].t[i].tmul[mNote] = new_tmul;
-			k.p[k.pattern].t[i].tmul[mAltNote] = new_tmul;
-			k.p[k.pattern].t[i].tmul[mOct] = new_tmul;
-			k.p[k.pattern].t[i].tmul[mGlide] = new_tmul;
-			k.p[k.pattern].t[i].tmul[mDur] = new_tmul;
+			if (note_div_sync) {
+				if (mode == mTr || mode == mRpt) {
+					k.p[k.pattern].t[i].tmul[mTr] = new_tmul;
+					k.p[k.pattern].t[i].tmul[mNote] = new_tmul;
+				} else {
+					k.p[k.pattern].t[i].tmul[mRpt] = new_tmul;
+					k.p[k.pattern].t[i].tmul[mAltNote] = new_tmul;
+					k.p[k.pattern].t[i].tmul[mOct] = new_tmul;
+					k.p[k.pattern].t[i].tmul[mGlide] = new_tmul;
+					k.p[k.pattern].t[i].tmul[mDur] = new_tmul;
+				}
+			} else {
+				k.p[k.pattern].t[i].tmul[mTr] = new_tmul;
+				k.p[k.pattern].t[i].tmul[mNote] = new_tmul;
+				k.p[k.pattern].t[i].tmul[mRpt] = new_tmul;
+				k.p[k.pattern].t[i].tmul[mAltNote] = new_tmul;
+				k.p[k.pattern].t[i].tmul[mOct] = new_tmul;
+				k.p[k.pattern].t[i].tmul[mGlide] = new_tmul;
+				k.p[k.pattern].t[i].tmul[mDur] = new_tmul;
+			}
 		}
 		break;
 	default:

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -90,6 +90,8 @@ typedef struct {
 	uint8_t preset;
 	bool note_sync;
 	uint8_t loop_sync;
+	bool note_div_sync;
+	uint8_t div_sync;
 	uint8_t cue_div;
 	uint8_t cue_steps;
 	uint8_t meta;

--- a/src/ansible_preset_docdef.c
+++ b/src/ansible_preset_docdef.c
@@ -186,6 +186,15 @@ json_docdef_t ansible_app_docdefs[] = {
 					}),
 				},
 				{
+					.name = "sync_mode",
+					.read = json_read_scalar,
+					.write = json_write_number,
+					.params = &((json_read_scalar_params_t) {
+						.dst_size = sizeof_field(nvram_data_t, kria_state.sync_mode),
+						.dst_offset = offsetof(nvram_data_t, kria_state.sync_mode),
+					}),
+				},
+				{
 					.name = "note_sync",
 					.read = json_read_scalar,
 					.write = json_write_bool,
@@ -201,6 +210,24 @@ json_docdef_t ansible_app_docdefs[] = {
 					.params = &((json_read_scalar_params_t) {
 						.dst_size = sizeof_field(nvram_data_t, kria_state.loop_sync),
 						.dst_offset = offsetof(nvram_data_t, kria_state.loop_sync),
+					}),
+				},
+				{
+					.name = "note_div_sync",
+					.read = json_read_scalar,
+					.write = json_write_number,
+					.params = &((json_read_scalar_params_t) {
+						.dst_size = sizeof_field(nvram_data_t, kria_state.note_div_sync),
+						.dst_offset = offsetof(nvram_data_t, kria_state.note_div_sync),
+					}),
+				},
+				{
+					.name = "div_sync",
+					.read = json_read_scalar,
+					.write = json_write_number,
+					.params = &((json_read_scalar_params_t) {
+						.dst_size = sizeof_field(nvram_data_t, kria_state.div_sync),
+						.dst_offset = offsetof(nvram_data_t, kria_state.div_sync),
 					}),
 				},
 				{


### PR DESCRIPTION
* In analogy with note sync/loop sync, adds the ability to simultaneously apply time division changes across all tracks, all parameters within a track, or only trigger + note within each track while leaving other parameters independent. These settings are configured by glyphs on the clock config page that look like the ones on the config page.
* Moves the "phase sync on time div changes" to a glyph on the bottom center of the clock config page, since it seemed to fit in better here. Going to call this feature "division cueing" rather than "division sync", as I think "division sync" makes more sense for the first item above.
* Adds `sync_mode` (for configuring whether to cue divisions) to the docdef so it will be saved to disk, this was missing.

Discussion [here](https://llllllll.co/t/ansible-development-and-beta-firmware-discussion/23118/26).