### PR TITLE
bugfix(kria): fix relocating loop on trig + note pages

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -1750,11 +1750,17 @@ void handler_KriaGridKey(s32 data) {
 
 						if(loop_count == 0) {
 							if(loop_last == -1) {
-								update_loop_start(loop_edit, loop_first, mTr);
 								if(loop_first == k.p[k.pattern].t[loop_edit].lstart[mTr]) {
+									update_loop_start(loop_edit, loop_first, mTr);
 									update_loop_end(loop_edit, loop_first, mTr);
 									if (note_sync) {
+										update_loop_start(loop_edit, loop_first, mNote);
 										update_loop_end(loop_edit, loop_first, mNote);
+									}
+								} else {
+									update_loop_start(loop_edit, loop_first, mTr);
+									if (note_sync) {
+										update_loop_start(loop_edit, loop_first, mTr);
 									}
 								}
 							}
@@ -1818,14 +1824,17 @@ void handler_KriaGridKey(s32 data) {
 
 						if(loop_count == 0) {
 							if(loop_last == -1) {
-								update_loop_start(track, loop_first, mNote);
-								if (note_sync) {
-									update_loop_start(track, loop_first, mTr);
-								}
 								if(loop_first == k.p[k.pattern].t[track].lstart[mNote]) {
+									update_loop_start(track, loop_first, mNote);
 									update_loop_end(track, loop_first, mNote);
 									if (note_sync) {
+										update_loop_start(track, loop_first, mTr);
 										update_loop_end(track, loop_first, mTr);
+									}
+								} else {
+									update_loop_start(track, loop_first, mNote);
+									if (note_sync) {
+										update_loop_start(track, loop_first, mTr);
 									}
 								}
 							}


### PR DESCRIPTION
After the changes for note sync on + loop sync off, relocating the loop by holding the Loop Mod key and pressing a loop start point was not working on the Trigger and Note pages, it would always set a 1-step loop.