### PR TITLE
feature(kria/mp): apply temporary shift to scale steps

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -2167,12 +2167,8 @@ void handler_KriaGridKey(s32 data) {
 						}
 					}
 					else if(x < 8) {
-						if(y > 4) {
+						if(y > 4)
 							k.p[k.pattern].scale = (y - 5) * 8 + x;
-							for (uint8_t i = 0; i < 8; i++) {
-								scale_adj[i] = 0;
-							}
-						}
 					}
 					else {
 						uint8_t i;
@@ -2705,7 +2701,7 @@ void refresh_kria_oct(void) {
 			if(i == pos[track][mOct]) {
 				monomeLedBuffer[R6 - octsum*16 + i] += 4;
 			}
-		}
+		}
 		break;
 	}
 }

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -2167,8 +2167,12 @@ void handler_KriaGridKey(s32 data) {
 						}
 					}
 					else if(x < 8) {
-						if(y > 4)
+						if(y > 4) {
 							k.p[k.pattern].scale = (y - 5) * 8 + x;
+							for (uint8_t i = 0; i < 8; i++) {
+								scale_adj[i] = 0;
+							}
+						}
 					}
 					else {
 						uint8_t i;
@@ -2701,7 +2705,7 @@ void refresh_kria_oct(void) {
 			if(i == pos[track][mOct]) {
 				monomeLedBuffer[R6 - octsum*16 + i] += 4;
 			}
-		}
+		}
 		break;
 	}
 }

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -2167,8 +2167,12 @@ void handler_KriaGridKey(s32 data) {
 						}
 					}
 					else if(x < 8) {
-						if(y > 4)
+						if(y > 4) {
 							k.p[k.pattern].scale = (y - 5) * 8 + x;
+							for (uint8_t i = 0; i < 8; i++) {
+								scale_adj[i] = 0;
+							}
+						}
 					}
 					else {
 						uint8_t i;

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -3323,7 +3323,7 @@ void mp_note_on(uint8_t n) {
 		if(mp_clock_count < 1) {
 			mp_clock_count++;
 			note_now[0] = n;
-			dac_set_value(0, ET[cur_scale[7-n]] << 2);
+			dac_set_value(0, ET[(int)cur_scale[7-n] + scale_adj[7-n]] << 2);
 			set_tr(TR1);
 		}
 		break;
@@ -3332,7 +3332,7 @@ void mp_note_on(uint8_t n) {
 			mp_clock_count++;
 			w = get_note_slot(2);
 			note_now[w] = n;
-			dac_set_value(w, ET[cur_scale[7-n]] << 2);
+			dac_set_value(w, ET[(int)cur_scale[7-n] + scale_adj[7-n]] << 2);
 			set_tr(TR1 + w);
 		}
 		break;
@@ -3341,7 +3341,7 @@ void mp_note_on(uint8_t n) {
 			mp_clock_count++;
 			w = get_note_slot(4);
 			note_now[w] = n;
-			dac_set_value(w, ET[cur_scale[7-n]] << 2);
+			dac_set_value(w, ET[(int)cur_scale[7-n] + scale_adj[7-n]] << 2);
 			set_tr(TR1 + w);
 		}
 		break;


### PR DESCRIPTION
Performance feature proposed [here](https://llllllll.co/t/ansible-development-and-beta-firmware-discussion/23118/52) which allows you to use a two-key gesture on the scale page to offset certain scale steps without affecting the rest of the scale. These are cleared when you change the selected scale, but not on a pattern change, and they are not persisted to flash.