### PR TITLE
bugfix(kria): moving tr loop start didn't update note loop w/ note sync

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -1765,7 +1765,7 @@ void handler_KriaGridKey(s32 data) {
 								} else {
 									update_loop_start(loop_edit, loop_first, mTr);
 									if (note_sync) {
-										update_loop_start(loop_edit, loop_first, mTr);
+										update_loop_start(loop_edit, loop_first, mNote);
 									}
 								}
 							}


### PR DESCRIPTION
The opposite loop start adjustment was working fine, as was updating both ends of either loop.