### PR TITLE
bugfix: some issues with 1.6.1 + ES -> 2.0.0 upgrade path

### DIFF
--- a/src/ansible_preset_docdef.c
+++ b/src/ansible_preset_docdef.c
@@ -1094,6 +1094,7 @@ json_docdef_t ansible_app_docdefs[] = {
 										.fresh = true,
 										.state = &ansible_json_read_buffer_state,
 										.params = &((json_read_buffer_params_t) {
+											.dst_size = sizeof_field(nvram_data_t, es_state.e[0].glyph),
 											.dst_offset = offsetof(nvram_data_t, es_state.e[0].glyph),
 										}),
 									},

--- a/src/ansible_usb_disk.c
+++ b/src/ansible_usb_disk.c
@@ -150,6 +150,7 @@ static void blink_write(void* o) {
 }
 
 void set_mode_usb_disk(void) {
+	clock = &clock_null;
 	update_leds(0);
 	app_event_handlers[kEventKey] = &handler_UsbDiskKey;
 	app_event_handlers[kEventFront] = &handler_UsbDiskFront;

--- a/tools/flash_tools/schemata/ansible/v161.py
+++ b/tools/flash_tools/schemata/ansible/v161.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from schemata.ansible.ansible_preset_schema import AnsiblePresetSchema
 
 
@@ -298,6 +300,9 @@ typedef const struct {
                                                     'note',
                                                     'dur',
                                                     'rpt',
+                                                ]),
+                                                self.extract_rpt_bits(track),
+                                                self.array_1d_settings(track, [
                                                     'alt_note',
                                                     'glide',
                                                 ]),
@@ -341,6 +346,17 @@ typedef const struct {
                 ),
             ]),
         )
+
+    def extract_rpt_bits(self, track):
+        return OrderedDict([
+            self.pair(
+                track,
+                'rpt:rptBits',
+                lambda xs, f: self.encode_bytes(
+                    map(lambda rpt: ~(0xFF << rpt) & 0xFF, xs)
+                )
+            )
+        ])
 
     def extract_mp_state(self, state):
         return self.combine(


### PR DESCRIPTION
* Negative int16 fields in hex dump would cause conversion to fail
* Missing size meant presence of ES preset glyphs in JSON would cause load to fail
* Now that ratchet behavior depends on `rpt` and `rptBits` state, both need to be populated when producing a JSON file
* Clear clock handler of running app when entering USB disk mode, because it could interfere with the busy indicator