### PR TITLE
feature: tuning table reassignment interface

### DIFF
--- a/src/ansible_arc.c
+++ b/src/ansible_arc.c
@@ -1997,36 +1997,16 @@ static void generate_scales(uint8_t n) {
 }
 
 static void levels_dac_refresh(void) {
-	if(l.mode[0]) {
-		if(l.scale[0])
-			dac_set_value(0, ET[ levels_scales[0][ l.note[0][play] ] + l.octave[0]*12] << 2);
-		else
-			dac_set_value(0, ET[ l.note[0][play] + l.octave[0]*12] << 2);
+	for (uint8_t i = 0; i < 4; i++) {
+		if (l.mode[i]) {
+			if (l.scale[i]) {
+				dac_set_value(i, tuning_table[i][ levels_scales[i][ l.note[i][play] ] + l.octave[i]*12 ] << 2);
+			} else {
+				dac_set_value(i, tuning_table[i][ l.note[i][play] + l.octave[i]*12 ] << 2);
+			}
+			break;
+		} else {
+			dac_set_value(i, (l.pattern[i][play] + l.offset[i]) << (2 + l.range[i]));
+		}
 	}
-	else
-		dac_set_value(0, (l.pattern[0][play] + l.offset[0]) << (2 + l.range[0]));
-	if(l.mode[1]) {
-		if(l.scale[1])
-			dac_set_value(1, ET[ levels_scales[1][ l.note[1][play] ] + l.octave[1]*12] << 2);
-		else
-			dac_set_value(1, ET[ l.note[1][play] + l.octave[1]*12] << 2);
-	}
-	else
-		dac_set_value(1, (l.pattern[1][play] + l.offset[1]) << (2 + l.range[1]));
-	if(l.mode[2]) {
-		if(l.scale[2])
-			dac_set_value(2, ET[ levels_scales[2][ l.note[2][play] ] + l.octave[2]*12] << 2);
-		else
-			dac_set_value(2, ET[ l.note[2][play] + l.octave[2]*12] << 2);
-	}
-	else
-		dac_set_value(2, (l.pattern[2][play] + l.offset[2]) << (2 + l.range[2]));
-	if(l.mode[3]) {
-		if(l.scale[3])
-			dac_set_value(3, ET[ levels_scales[3][ l.note[3][play] ] + l.octave[3]*12] << 2);
-		else
-			dac_set_value(3, ET[ l.note[3][play] + l.octave[3]*12] << 2);
-	}
-	else
-		dac_set_value(3, (l.pattern[3][play] + l.offset[3]) << (2 + l.range[3]));
 }

--- a/src/ansible_arc.c
+++ b/src/ansible_arc.c
@@ -2000,9 +2000,9 @@ static void levels_dac_refresh(void) {
 	for (uint8_t i = 0; i < 4; i++) {
 		if (l.mode[i]) {
 			if (l.scale[i]) {
-				dac_set_value(i, tuning_table[i][ levels_scales[i][ l.note[i][play] ] + l.octave[i]*12 ] << 2);
+				dac_set_value(i, tuning_table[i][ levels_scales[i][ l.note[i][play] ] + l.octave[i]*12 ]);
 			} else {
-				dac_set_value(i, tuning_table[i][ l.note[i][play] + l.octave[i]*12 ] << 2);
+				dac_set_value(i, tuning_table[i][ l.note[i][play] + l.octave[i]*12 ]);
 			}
 			break;
 		} else {

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -396,16 +396,12 @@ void grid_keytimer(void) {
 					if (x == 14) {
 						// interpolate octaves and save
 						fit_tuning();
-						for (uint8_t i = 0; i < 4; i++) {
-							flashc_memcpy((void *)&f.tuning_table[i], tuning_table[i], sizeof(tuning_table[0]), true);
-						}
+						flashc_memcpy((void*)f.tuning_table, tuning_table, sizeof(tuning_table), true);
 						restore_grid_tuning();
 					}
 					if (x == 15) {
 						// save all tuning entries as-is
-						for (uint8_t i = 0; i < 4; i++) {
-							flashc_memcpy((void *)&f.tuning_table[i], tuning_table[i], sizeof(tuning_table[0]), true);
-						}
+						flashc_memcpy((void *)f.tuning_table, tuning_table, sizeof(tuning_table), true);
 						restore_grid_tuning();
 					}
 				}

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -1753,11 +1753,17 @@ void handler_KriaGridKey(s32 data) {
 
 						if(loop_count == 0) {
 							if(loop_last == -1) {
-								update_loop_start(loop_edit, loop_first, mTr);
 								if(loop_first == k.p[k.pattern].t[loop_edit].lstart[mTr]) {
+									update_loop_start(loop_edit, loop_first, mTr);
 									update_loop_end(loop_edit, loop_first, mTr);
 									if (note_sync) {
+										update_loop_start(loop_edit, loop_first, mNote);
 										update_loop_end(loop_edit, loop_first, mNote);
+									}
+								} else {
+									update_loop_start(loop_edit, loop_first, mTr);
+									if (note_sync) {
+										update_loop_start(loop_edit, loop_first, mTr);
 									}
 								}
 							}
@@ -1821,14 +1827,17 @@ void handler_KriaGridKey(s32 data) {
 
 						if(loop_count == 0) {
 							if(loop_last == -1) {
-								update_loop_start(track, loop_first, mNote);
-								if (note_sync) {
-									update_loop_start(track, loop_first, mTr);
-								}
 								if(loop_first == k.p[k.pattern].t[track].lstart[mNote]) {
+									update_loop_start(track, loop_first, mNote);
 									update_loop_end(track, loop_first, mNote);
 									if (note_sync) {
+										update_loop_start(track, loop_first, mTr);
 										update_loop_end(track, loop_first, mTr);
+									}
+								} else {
+									update_loop_start(track, loop_first, mNote);
+									if (note_sync) {
+										update_loop_start(track, loop_first, mTr);
 									}
 								}
 							}

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -292,10 +292,7 @@ void refresh_grid_tuning(void) {
 
 	// lit key indicating position
 	uint8_t tuning_slot = (int)(tuning_octave * 12) + tuning_octave_offset[tuning_track];
-	fix16_t dac_range_percent = fix16_div(
-		fix16_from_int(tuning_table[tuning_track][tuning_slot]),
-		fix16_from_int(DAC_10V));
-	int dac_step = fix16_to_int(fix16_mul(dac_range_percent, fix16_from_int(256)));
+	uint8_t dac_step = tuning_table[tuning_track][tuning_slot] >> 6;
 	memset(monomeLedBuffer + R6, 3, dac_step / 16);
 	monomeLedBuffer[R6 + dac_step / 16] = dac_step % 16;
 

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -292,13 +292,13 @@ void refresh_grid_tuning(void) {
 
 	// lit key indicating position
 	int tuning_slot = (int)(tuning_octave * 12) + tuning_octave_offset[tuning_track];
-	float dac_range_percent = (float)tuning_table[tuning_track][tuning_slot] / (float)(DAC_10V >> 2);
+	float dac_range_percent = (float)tuning_table[tuning_track][tuning_slot] / (float)(DAC_10V);
 	int dac_step = (int)(256.0 * dac_range_percent);
 	monomeLedBuffer[R6 + dac_step / 16] = dac_step % 16;
 
 	// tuning steps either direction
 	for (uint8_t i = 0; i < 8; i++) {
-		if ((DAC_10V >> 2) - tuning_table[tuning_track][tuning_slot] > (1 << i)) {
+		if ((DAC_10V) - tuning_table[tuning_track][tuning_slot] > (1 << i)) {
 			monomeLedBuffer[R7 + 8 + i] = 2*i + 1;
 		}
 		if (tuning_table[tuning_track][tuning_slot] > (1 << i)) {
@@ -318,7 +318,7 @@ static void restore_grid_tuning(void) {
 			tuning_table[i][
 		        	(int)(tuning_octave * 12) +
 				tuning_octave_offset[i]
-			] << 2);
+			]);
 		set_tr(TR1 + i);
 	}
 }
@@ -904,7 +904,7 @@ static void kria_set_note(uint8_t trackNum) {
 			(int)cur_scale[noteInScale] +
 			scale_adj[noteInScale] +
 			(int)((oct[trackNum]+octaveBump) * 12)
-		] << 2);
+		]);
 }
 
 void clock_kria_track( uint8_t trackNum ) {
@@ -1781,7 +1781,7 @@ void handler_KriaGridKey(s32 data) {
 							tuning_table[y][
 							        (int)(tuning_octave * 12) +
 								tuning_octave_offset[y]
-							] << 2);
+							]);
 						set_tr(TR1 + y);
 					}
 				}
@@ -1794,18 +1794,18 @@ void handler_KriaGridKey(s32 data) {
 						tuning_table[i][
 						        (int)(tuning_octave * 12) +
 							tuning_octave_offset[i]
-						] << 2);
+						]);
 				}
 			}
 			else if (y == 6) {
 				int tuning_slot = (int)(tuning_octave * 12) + tuning_octave_offset[tuning_track];
-				tuning_table[tuning_track][tuning_slot] = x * ((DAC_10V >> 2) / 16);
+				tuning_table[tuning_track][tuning_slot] = x * ((DAC_10V) / 16);
 				dac_set_value_noslew(
 					tuning_track,
 					tuning_table[tuning_track][
 					        (int)(tuning_octave * 12) +
 						tuning_octave_offset[tuning_track]
-					] << 2);
+					]);
 			}
 			else if (y == 7) {
 				int tuning_slot = (int)(tuning_octave * 12) + tuning_octave_offset[tuning_track];
@@ -1814,19 +1814,19 @@ void handler_KriaGridKey(s32 data) {
 					tuning_table[tuning_track][tuning_slot] = sum_clip(
 						tuning_table[tuning_track][tuning_slot],
 						1 << (x - 8),
-					        DAC_10V >> 2);
+					        DAC_10V);
 				} else {
 					tuning_table[tuning_track][tuning_slot] = sum_clip(
 						tuning_table[tuning_track][tuning_slot],
 						- (1 << (8 - x)),
-					        DAC_10V >> 2);
+					        DAC_10V);
 				}
 				dac_set_value_noslew(
 					tuning_track,
 					tuning_table[tuning_track][
 					        (int)(tuning_octave * 12) +
 						tuning_octave_offset[tuning_track]
-					] << 2);
+					]);
 			}
 		}
 	}
@@ -3540,7 +3540,7 @@ void mp_note_on(uint8_t n) {
 		if(mp_clock_count < 1) {
 			mp_clock_count++;
 			note_now[0] = n;
-			dac_set_value(0, tuning_table[0][(int)cur_scale[7-n] + scale_adj[7-n]] << 2);
+			dac_set_value(0, tuning_table[0][(int)cur_scale[7-n] + scale_adj[7-n]]);
 			set_tr(TR1);
 		}
 		break;
@@ -3549,7 +3549,7 @@ void mp_note_on(uint8_t n) {
 			mp_clock_count++;
 			w = get_note_slot(2);
 			note_now[w] = n;
-			dac_set_value(w, tuning_table[w][(int)cur_scale[7-n] + scale_adj[7-n]] << 2);
+			dac_set_value(w, tuning_table[w][(int)cur_scale[7-n] + scale_adj[7-n]]);
 			set_tr(TR1 + w);
 		}
 		break;
@@ -3558,7 +3558,7 @@ void mp_note_on(uint8_t n) {
 			mp_clock_count++;
 			w = get_note_slot(4);
 			note_now[w] = n;
-			dac_set_value(w, tuning_table[w][(int)cur_scale[7-n] + scale_adj[7-n]] << 2);
+			dac_set_value(w, tuning_table[w][(int)cur_scale[7-n] + scale_adj[7-n]]);
 			set_tr(TR1 + w);
 		}
 		break;
@@ -4378,7 +4378,7 @@ static void es_note_on(s8 x, s8 y, u8 from_pattern, u16 timer, u8 voices) {
         note_index = 0;
     else if (note_index > 119)
         note_index = 119;
-    dac_set_value_noslew(note, tuning_table[note][note_index] << 2);
+    dac_set_value_noslew(note, tuning_table[note][note_index]);
     dac_update_now();
     set_tr(TR1 + note);
 
@@ -4399,7 +4399,7 @@ static void es_update_pitches(void) {
             note_index = 0;
         else if (note_index > 119)
             note_index = 119;
-        dac_set_value_noslew(i, tuning_table[i][note_index] << 2);
+        dac_set_value_noslew(i, tuning_table[i][note_index]);
         dac_update_now();
     }
 }

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -9,6 +9,7 @@
 #include "dac.h"
 #include "util.h" // rnd
 #include "music.h"
+#include "libfixmath/fix16.h"
 #include "init_common.h"
 #include "ii.h"
 
@@ -291,9 +292,11 @@ void refresh_grid_tuning(void) {
 	monomeLedBuffer[R5 + 15] = L1; // save as-is key
 
 	// lit key indicating position
-	int tuning_slot = (int)(tuning_octave * 12) + tuning_octave_offset[tuning_track];
-	float dac_range_percent = (float)tuning_table[tuning_track][tuning_slot] / (float)(DAC_10V);
-	int dac_step = (int)(256.0 * dac_range_percent);
+	uint8_t tuning_slot = (int)(tuning_octave * 12) + tuning_octave_offset[tuning_track];
+	fix16_t dac_range_percent = fix16_div(
+		fix16_from_int(tuning_table[tuning_track][tuning_slot]),
+		fix16_from_int(DAC_10V));
+	int dac_step = fix16_to_int(fix16_mul(dac_range_percent, fix16_from_int(256)));
 	monomeLedBuffer[R6 + dac_step / 16] = dac_step % 16;
 
 	// tuning steps either direction

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -275,7 +275,7 @@ void refresh_grid_tuning(void) {
 
 	for (uint8_t i = 0; i < 4; i++) {
 		if (tuning_track == i) {
-			memset(monomeLedBuffer + i*16 + 2, L0 + 2, 12);
+			memset(monomeLedBuffer + i*16 + 2, L1, 12);
 		} else {
 			memset(monomeLedBuffer + i*16 + 2, L0, 12);
 		}
@@ -298,8 +298,12 @@ void refresh_grid_tuning(void) {
 
 	// tuning steps either direction
 	for (uint8_t i = 0; i < 8; i++) {
-		monomeLedBuffer[R7 + 8 + i] = 2*i + 1;
-		monomeLedBuffer[R7 + 7 - i] = 2*i + 1;
+		if ((DAC_10V >> 2) - tuning_table[tuning_track][tuning_slot] > (1 << i)) {
+			monomeLedBuffer[R7 + 8 + i] = 2*i + 1;
+		}
+		if (tuning_table[tuning_track][tuning_slot] > (1 << i)) {
+			monomeLedBuffer[R7 + 7 - i] = 2*i + 1;
+		}
 	}
 }
 

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -38,6 +38,7 @@ u8 key_times[128];
 bool clock_external;
 bool view_clock;
 bool view_config;
+bool view_tuning;
 uint32_t clock_period;
 uint8_t clock_count;
 uint8_t clock_mul;
@@ -49,6 +50,11 @@ u32 clock_deltas[4];
 
 uint8_t time_rough;
 uint8_t time_fine;
+
+uint8_t tuning_track;
+uint8_t tuning_octave;
+int16_t tuning_octave_offset[4];
+bool tuning_note_on[4];
 
 uint8_t cue_div;
 uint8_t cue_steps;
@@ -264,13 +270,64 @@ void refresh_preset(void) {
 	monome_set_quadrant_flag(1);
 }
 
+void refresh_grid_tuning(void) {
+	memset(monomeLedBuffer,0,128);
+
+	for (uint8_t i = 0; i < 4; i++) {
+		if (tuning_track == i) {
+			memset(monomeLedBuffer + i*16 + 2, L0 + 2, 12);
+		} else {
+			memset(monomeLedBuffer + i*16 + 2, L0, 12);
+		}
+		if (tuning_note_on[i]) {
+			monomeLedBuffer[(int)i*16 + tuning_octave_offset[i] + 2] += 4;
+	        }
+	}
+
+	memset(monomeLedBuffer + R5, L0, 5);
+	monomeLedBuffer[R5 + tuning_octave] = L1;
+	monomeLedBuffer[R5 + 12] = L1; // reload / longpress to restore factory default
+	monomeLedBuffer[R5 + 14] = L1; // save interpolated key
+	monomeLedBuffer[R5 + 15] = L1; // save as-is key
+
+	// lit key indicating position
+	int tuning_slot = (int)(tuning_octave * 12) + tuning_octave_offset[tuning_track];
+	float dac_range_percent = (float)tuning_table[tuning_track][tuning_slot] / (float)(DAC_10V >> 2);
+	int dac_step = (int)(256.0 * dac_range_percent);
+	monomeLedBuffer[R6 + dac_step / 16] = dac_step % 16;
+
+	// tuning steps either direction
+	for (uint8_t i = 0; i < 8; i++) {
+		monomeLedBuffer[R7 + 8 + i] = 2*i + 1;
+		monomeLedBuffer[R7 + 7 - i] = 2*i + 1;
+	}
+}
+
+static void restore_grid_tuning(void) {
+	tuning_octave = 0;
+	tuning_track = 0;
+	for (uint8_t i = 0; i < 4; i++) {
+		tuning_note_on[i] = true;
+		tuning_octave_offset[i] = 0;
+		dac_set_value_noslew(
+			i,
+			tuning_table[i][
+		        	(int)(tuning_octave * 12) +
+				tuning_octave_offset[i]
+			] << 2);
+		set_tr(TR1 + i);
+	}
+}
+
 void grid_keytimer(void) {
 	for(uint8_t i1=0;i1<key_count;i1++) {
 		if(key_times[held_keys[i1]])
 		if(--key_times[held_keys[i1]]==0) {
+			uint8_t x = held_keys[i1] % 16;
+			uint8_t y = held_keys[i1] / 16;
 			if(preset_mode == 1) {
-				if(held_keys[i1] % 16 == 0) {
-					preset = held_keys[i1] / 16;
+				if(x == 0) {
+					preset = y;
 
 					// WRITE PRESET
 
@@ -321,6 +378,33 @@ void grid_keytimer(void) {
 			}
 			else if(ansible_mode == mGridKria) {
 				grid_keytimer_kria(held_keys[i1]);
+			}
+
+			if (view_tuning) {
+				if (y == 5) {
+					if (x == 12) {
+						// reload factory default
+						for (uint8_t i = 0; i < 4; i++) {
+							memcpy((void *)&tuning_table[i], ET, sizeof(ET));
+						}
+						restore_grid_tuning();
+					}
+					if (x == 14) {
+						// interpolate octaves and save
+						fit_tuning();
+						for (uint8_t i = 0; i < 4; i++) {
+							flashc_memcpy((void *)&f.tuning_table[i], tuning_table[i], sizeof(tuning_table[0]), true);
+						}
+						restore_grid_tuning();
+					}
+					if (x == 15) {
+						// save all tuning entries as-is
+						for (uint8_t i = 0; i < 4; i++) {
+							flashc_memcpy((void *)&f.tuning_table[i], tuning_table[i], sizeof(tuning_table[0]), true);
+						}
+						restore_grid_tuning();
+					}
+				}
 			}
 
 			// print_dbg("\rlong press: ");
@@ -787,8 +871,8 @@ void clock_kria(uint8_t phase) {
 	}
 }
 
-static inline int8_t sum_clip_octave(int8_t l, int8_t r) {
-	return min(5, max(0, l + r));
+static inline int sum_clip(int l, int r, int clip) {
+	return min(clip, max(0, l + r));
 }
 
 void clock_kria_note(kria_track* track, uint8_t trackNum) {
@@ -798,7 +882,7 @@ void clock_kria_note(kria_track* track, uint8_t trackNum) {
 		dur[trackNum] = (u16)(unscaled * clock_scale);
 	}
 	if(kria_next_step(trackNum, mOct)) {
-		oct[trackNum] = sum_clip_octave(track->octshift, track->oct[pos[trackNum][mOct]]);
+		oct[trackNum] = sum_clip(track->octshift, track->oct[pos[trackNum][mOct]], 5);
 	}
 	if(kria_next_step(trackNum, mNote)) {
 		note[trackNum] = track->note[pos[trackNum][mNote]];
@@ -814,7 +898,13 @@ void clock_kria_note(kria_track* track, uint8_t trackNum) {
 static void kria_set_note(uint8_t trackNum) {
 	u8 noteInScale = (note[trackNum] + alt_note[trackNum]) % 7; // combine both note params
 	u8 octaveBump = (note[trackNum] + alt_note[trackNum]) / 7; // if it wrapped around the octave, bump it
-	dac_set_value(trackNum, ET[(int)cur_scale[noteInScale] + scale_adj[noteInScale] + (int)((oct[trackNum]+octaveBump) * 12)] << 2);
+	dac_set_value(
+		trackNum,
+		tuning_table[trackNum][
+			(int)cur_scale[noteInScale] +
+			scale_adj[noteInScale] +
+			(int)((oct[trackNum]+octaveBump) * 12)
+		] << 2);
 }
 
 void clock_kria_track( uint8_t trackNum ) {
@@ -1524,6 +1614,17 @@ void handler_KriaGridKey(s32 data) {
 					}
 				}
 			}
+			else if(view_tuning) {
+				if (y == 5) {
+					if (x == 12) {
+						init_tuning();
+						restore_grid_tuning();
+					} else if (x == 14) {
+						fit_tuning();
+						restore_grid_tuning();
+					}
+				}
+			}
 		}
 	}
 
@@ -1647,7 +1748,80 @@ void handler_KriaGridKey(s32 data) {
 
 				flashc_memset8((void*)&(f.kria_state.loop_sync), loop_sync, 1, true);
 			}
+			else if (y == 7 && x == 14) {
+				view_config = false;
+				view_clock = false;
+				view_tuning = true;
+
+				grid_refresh = &refresh_grid_tuning;
+				restore_grid_tuning();
+			}
 			monomeFrameDirty++;
+		}
+	}
+	else if(view_tuning) {
+		if(z) {
+			if (y <= 4) {
+				if (x >= 2 && x <= 13) {
+					if (tuning_track == y && tuning_note_on[y] && x == (tuning_octave_offset[y] + 2)) {
+						tuning_note_on[y] = false;
+						clr_tr(TR1 + y);
+					} else {
+						tuning_track = y;
+						tuning_note_on[y] = true;
+						tuning_octave_offset[y] = (int)x - 2;
+						dac_set_value_noslew(
+							y,
+							tuning_table[y][
+							        (int)(tuning_octave * 12) +
+								tuning_octave_offset[y]
+							] << 2);
+						set_tr(TR1 + y);
+					}
+				}
+			}
+			else if (y == 5 && x <= 4) {
+				tuning_octave = x;
+				for (uint8_t i = 0; i < 4; i++) {
+					dac_set_value_noslew(
+						i,
+						tuning_table[i][
+						        (int)(tuning_octave * 12) +
+							tuning_octave_offset[i]
+						] << 2);
+				}
+			}
+			else if (y == 6) {
+				int tuning_slot = (int)(tuning_octave * 12) + tuning_octave_offset[tuning_track];
+				tuning_table[tuning_track][tuning_slot] = x * ((DAC_10V >> 2) / 16);
+				dac_set_value_noslew(
+					tuning_track,
+					tuning_table[tuning_track][
+					        (int)(tuning_octave * 12) +
+						tuning_octave_offset[tuning_track]
+					] << 2);
+			}
+			else if (y == 7) {
+				int tuning_slot = (int)(tuning_octave * 12) + tuning_octave_offset[tuning_track];
+
+				if (x >= 8) {
+					tuning_table[tuning_track][tuning_slot] = sum_clip(
+						tuning_table[tuning_track][tuning_slot],
+						1 << (x - 8),
+					        DAC_10V >> 2);
+				} else {
+					tuning_table[tuning_track][tuning_slot] = sum_clip(
+						tuning_table[tuning_track][tuning_slot],
+						- (1 << (8 - x)),
+					        DAC_10V >> 2);
+				}
+				dac_set_value_noslew(
+					tuning_track,
+					tuning_table[tuning_track][
+					        (int)(tuning_octave * 12) +
+						tuning_octave_offset[tuning_track]
+					] << 2);
+			}
 		}
 	}
 	// NORMAL
@@ -2439,10 +2613,17 @@ void handler_KriaKey(s32 data) {
 		view_config = false;
 		break;
 	case 2:
-		grid_refresh = &refresh_kria;
-		view_config = false;
+		if (!view_tuning) {
+			grid_refresh = &refresh_kria;
+			view_config = false;
+		}
 		break;
 	case 3:
+		if (view_tuning) {
+			view_tuning = false;
+			resume_kria();
+			break;
+		}
 		grid_refresh = &refresh_kria_config;
 		view_config = true;
 		view_clock = false;
@@ -2684,7 +2865,7 @@ void refresh_kria_oct(void) {
 
 		for(uint8_t i=0;i<16;i++) {
 			const uint8_t octshift = k.p[k.pattern].t[track].octshift;
-			const int8_t octsum = sum_clip_octave(k.p[k.pattern].t[track].oct[i], (int)octshift);
+			const int8_t octsum = sum_clip(k.p[k.pattern].t[track].oct[i], (int)octshift, 5);
 
 			for(uint8_t j=0;j<=5;j++) {
 				if (octsum >= octshift) {
@@ -2968,6 +3149,8 @@ void refresh_kria_config(void) {
 	monomeLedBuffer[R5 + 11] = i;
 	monomeLedBuffer[R5 + 12] = i;
 	monomeLedBuffer[R5 + 13] = i;
+
+	monomeLedBuffer[R7 + 14] = L0;
 }
 
 
@@ -3334,7 +3517,7 @@ void mp_note_on(uint8_t n) {
 		if(mp_clock_count < 1) {
 			mp_clock_count++;
 			note_now[0] = n;
-			dac_set_value(0, ET[(int)cur_scale[7-n] + scale_adj[7-n]] << 2);
+			dac_set_value(0, tuning_table[0][(int)cur_scale[7-n] + scale_adj[7-n]] << 2);
 			set_tr(TR1);
 		}
 		break;
@@ -3343,7 +3526,7 @@ void mp_note_on(uint8_t n) {
 			mp_clock_count++;
 			w = get_note_slot(2);
 			note_now[w] = n;
-			dac_set_value(w, ET[(int)cur_scale[7-n] + scale_adj[7-n]] << 2);
+			dac_set_value(w, tuning_table[w][(int)cur_scale[7-n] + scale_adj[7-n]] << 2);
 			set_tr(TR1 + w);
 		}
 		break;
@@ -3352,7 +3535,7 @@ void mp_note_on(uint8_t n) {
 			mp_clock_count++;
 			w = get_note_slot(4);
 			note_now[w] = n;
-			dac_set_value(w, ET[(int)cur_scale[7-n] + scale_adj[7-n]] << 2);
+			dac_set_value(w, tuning_table[w][(int)cur_scale[7-n] + scale_adj[7-n]] << 2);
 			set_tr(TR1 + w);
 		}
 		break;
@@ -4172,7 +4355,7 @@ static void es_note_on(s8 x, s8 y, u8 from_pattern, u16 timer, u8 voices) {
         note_index = 0;
     else if (note_index > 119)
         note_index = 119;
-    dac_set_value_noslew(note, ET[note_index] << 2);
+    dac_set_value_noslew(note, tuning_table[note][note_index] << 2);
     dac_update_now();
     set_tr(TR1 + note);
 
@@ -4193,7 +4376,7 @@ static void es_update_pitches(void) {
             note_index = 0;
         else if (note_index > 119)
             note_index = 119;
-        dac_set_value_noslew(i, ET[note_index] << 2);
+        dac_set_value_noslew(i, tuning_table[i][note_index] << 2);
         dac_update_now();
     }
 }

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -202,6 +202,7 @@ void set_mode_grid(void);
 void handler_GridFrontShort(s32 data);
 void handler_GridFrontLong(s32 data);
 void refresh_preset(void);
+void refresh_grid_tuning(void);
 void grid_keytimer(void);
 void ii_grid(uint8_t* data, uint8_t len);
 

--- a/src/ansible_preset_docdef.c
+++ b/src/ansible_preset_docdef.c
@@ -153,6 +153,25 @@ json_docdef_t ansible_shared_docdefs[] = {
 			})
 		})
 	},
+	{
+		.name = "tuning_table",
+		.read = json_read_array,
+		.write = json_write_array,
+		.state = &ansible_json_read_array_state,
+		.params = &((json_read_array_params_t) {
+			.array_len = sizeof_field(nvram_data_t, tuning_table) / sizeof_field(nvram_data_t, tuning_table[0]),
+			.item_size = sizeof_field(nvram_data_t, tuning_table[0]),
+			.item_docdef = &((json_docdef_t) {
+				.read = json_read_buffer,
+				.write = json_write_buffer,
+				.state = &ansible_json_read_buffer_state,
+				.params = &((json_read_buffer_params_t) {
+					.dst_size = sizeof_field(nvram_data_t, tuning_table[0]),
+					.dst_offset = offsetof(nvram_data_t, tuning_table),
+				}),
+			})
+		})
+	},
 };
 
 /////////

--- a/src/config.mk
+++ b/src/config.mk
@@ -78,6 +78,7 @@ CSRCS = \
        ../libavr32/src/euclidean/data.c \
        ../libavr32/src/euclidean/euclidean.c \
        ../libavr32/src/events.c     \
+       ../libavr32/src/libfixmath/fix16.c     \
        ../libavr32/src/i2c.c     \
        ../libavr32/src/init_ansible.c \
        ../libavr32/src/init_common.c \

--- a/src/main.c
+++ b/src/main.c
@@ -456,15 +456,12 @@ void default_tuning(void) {
 		for (uint8_t j = 0; j < 120; j++) {
 			tuning_table[i][j] = ET[j] << 2;
 		}
-		flashc_memcpy((void *)&f.tuning_table[i], tuning_table[i], sizeof(tuning_table[0]), true);
 	}
+	flashc_memcpy((void *)f.tuning_table, tuning_table, sizeof(tuning_table), true);
 }
 
 void init_tuning(void) {
-	for (uint8_t i = 0; i < 4; i++) {
-		memcpy((void*)&tuning_table[i], &f.tuning_table[i], sizeof(tuning_table[0]));
-	}
-	/* memcpy((void *)&tuning_table, &f.tuning_table, sizeof(tuning_table)); */
+	memcpy((void *)&tuning_table, &f.tuning_table, sizeof(tuning_table));
 }
 
 void fit_tuning(void) {

--- a/src/main.c
+++ b/src/main.c
@@ -41,6 +41,7 @@ usb flash
 // libavr32
 #include "types.h"
 #include "events.h"
+#include "libfixmath/fix16.h"
 #include "i2c.h"
 #include "init_ansible.h"
 #include "init_common.h"
@@ -466,15 +467,17 @@ void init_tuning(void) {
 
 void fit_tuning(void) {
 	for (uint8_t i = 0; i < 4; i++) {
-		float step = 0.0;
+		fix16_t step = 0;
 		for (uint8_t j = 0; j < 10; j++) {
-			float acc = tuning_table[i][j*12];
+			fix16_t acc = fix16_from_int(tuning_table[i][j*12]);
 			if (j < 9) {
-				step = (tuning_table[i][(j+1)*12] - tuning_table[i][j*12]) / 12.0;
+				step = fix16_div(
+					fix16_from_int(tuning_table[i][(j+1)*12] - tuning_table[i][j*12]),
+					fix16_from_int(12));
 			}
 			for (uint8_t k = j*12; k < (j+1)*12; k++) {
-				tuning_table[i][k] = acc;
-				acc += step;
+				tuning_table[i][k] = fix16_to_int(acc);
+				acc = fix16_add(acc, step);
 			}
 		}
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -453,13 +453,16 @@ void flash_read(void) {
 
 void default_tuning(void) {
 	for (uint8_t i = 0; i < 4; i++) {
-		flashc_memcpy((void *)&f.tuning_table[i], ET, sizeof(ET), true);
+		for (uint8_t j = 0; j < 120; j++) {
+			tuning_table[i][j] = ET[j] << 2;
+		}
+		flashc_memcpy((void *)&f.tuning_table[i], tuning_table[i], sizeof(tuning_table[0]), true);
 	}
 }
 
 void init_tuning(void) {
 	for (uint8_t i = 0; i < 4; i++) {
-		memcpy((void*)&tuning_table[i], &f.tuning_table[i], 120);
+		memcpy((void*)&tuning_table[i], &f.tuning_table[i], sizeof(tuning_table[0]));
 	}
 	/* memcpy((void *)&tuning_table, &f.tuning_table, sizeof(tuning_table)); */
 }

--- a/src/main.h
+++ b/src/main.h
@@ -60,15 +60,20 @@ typedef const struct {
 	midi_arp_state_t midi_arp_state;
 	tt_state_t tt_state;
 	uint8_t scale[16][8];
+	uint8_t tuning_table[4][120];
 } nvram_data_t;
 
 extern nvram_data_t f;
 extern ansible_mode_t ansible_mode;
 
 extern softTimer_t auxTimer[4];
+extern uint16_t tuning_table[4][120];
 
 
 void (*clock)(u8 phase);
+void init_tuning(void);
+void default_tuning(void);
+void fit_tuning(void);
 
 extern void handler_None(s32 data);
 extern void clock_null(u8 phase);

--- a/src/main.h
+++ b/src/main.h
@@ -60,7 +60,7 @@ typedef const struct {
 	midi_arp_state_t midi_arp_state;
 	tt_state_t tt_state;
 	uint8_t scale[16][8];
-	uint8_t tuning_table[4][120];
+	uint16_t tuning_table[4][120];
 } nvram_data_t;
 
 extern nvram_data_t f;


### PR DESCRIPTION
Instead of using the `ET[]` pitch lookup table directly, pitch assignments are made using a per-track `tuning_table[4][120]` which is stored / loaded in top-level flash state. This is loaded by default with `ET[i] << 2`, rather than using `<< 2` when calling `dac_set_value`, so that the 2 least significant bits of each tuning table slot are available for user adjustment.

To aid in calibration or experimental retuning, a Grid interface is added which allows reassigning tuning tables and saving/loading them to flash. All tracks may have all tuning table slots assigned independently across the full 10V range. To help with the most common retuning workflows, piecewise-linear interpolation between assigned octave values is available. This interpolation is implemented using `fix16.c` from libfixmath. A panic key allows the previously saved tuning table or the default `ET[]` tuning table to be restored at any time.