### PR TITLE
bugfix: fix levels & midi after preset load

### DIFF
--- a/src/ansible_arc.c
+++ b/src/ansible_arc.c
@@ -2004,7 +2004,6 @@ static void levels_dac_refresh(void) {
 			} else {
 				dac_set_value(i, tuning_table[i][ l.note[i][play] + l.octave[i]*12 ]);
 			}
-			break;
 		} else {
 			dac_set_value(i, (l.pattern[i][play] + l.offset[i]) << (2 + l.range[i]));
 		}

--- a/src/ansible_preset_docdef.c
+++ b/src/ansible_preset_docdef.c
@@ -10,7 +10,8 @@
 
 #define ALLOC_DEBUG 1
 
-
+// WARNING: order must match definition order of
+// connected_t, ansible_mode_t in main.h
 const char* connected_t_options[] = {
 	"conNONE",
 	"conARC",
@@ -23,10 +24,12 @@ const char* ansible_mode_options[] = {
 	"mArcCycles",
 	"mGridKria",
 	"mGridMP",
+	"mGridES",
 	"mMidiStandard",
 	"mMidiArp",
 	"mTT",
 };
+// END WARNING
 
 json_read_object_state_t ansible_root_object_state;
 json_read_object_state_t ansible_section_object_state;

--- a/src/main.h
+++ b/src/main.h
@@ -14,6 +14,9 @@
 
 #define KEY_HOLD_TIME 8
 
+// WARNING: order must match array order of
+// connected_t_options[], ansible_mode_options[]
+// in ansible_preset_docdef.c
 typedef enum {
 	conNONE,
 	conARC,
@@ -21,8 +24,6 @@ typedef enum {
 	conMIDI,
 	conFLASH
 } connected_t;
-
-connected_t connected;
 
 typedef enum {
 	mArcLevels,
@@ -35,6 +36,9 @@ typedef enum {
 	mTT,
 	mUsbDisk,
 } ansible_mode_t;
+// END WARNING
+
+connected_t connected;
 
 typedef struct {
 	connected_t connected;


### PR DESCRIPTION
Two tiny goofs that made Levels and MIDI apps unusable:
* I apparently got confused about flow control in `levels_dac_refresh` when working on tuning
* Some key enums are saved to JSON as strings specifically to improve backwards compatibility, but this does mean when a mode (Earthsea) is added that the string representation has to be added to the docdef as well. This was missing which caused MIDI to fail to load the right app when a device was plugged in. Added warning comments around this in both files.