### PR TITLE
feature(tuning): mod key to retune all slots at once

### DIFF
--- a/src/flash.sh
+++ b/src/flash.sh
@@ -1,3 +1,3 @@
-dfu-programmer at32uc3b0256 erase
-dfu-programmer at32uc3b0256 flash ansible.hex --suppress-bootloader-mem
-dfu-programmer at32uc3b0256 start
+dfu-programmer at32uc3b0512 erase
+dfu-programmer at32uc3b0512 flash ansible.hex --suppress-bootloader-mem
+dfu-programmer at32uc3b0512 start

--- a/src/update-firmware.command
+++ b/src/update-firmware.command
@@ -1,5 +1,5 @@
 #!/bin/sh
 cd "$(dirname "$0")"
-dfu-programmer at32uc3b0256 erase
-dfu-programmer at32uc3b0256 flash ansible.hex --suppress-bootloader-mem
-dfu-programmer at32uc3b0256 start	
+dfu-programmer at32uc3b0512 erase
+dfu-programmer at32uc3b0512 flash ansible.hex --suppress-bootloader-mem
+dfu-programmer at32uc3b0512 start


### PR DESCRIPTION
Useful for adding an offset to all DAC channels so you have some footroom while tuning the lowest note slot.

Also includes bug fixes for:
* keys on the 4th row of tuning mode cause would buffer overrun
* clock keys on the left side of clock config mode would toggle note div sync glyph
* changed reflashing scripts (update-firmware.command, flash.sh) from 0256 to 0512 chip. This should not really matter in practice, flashing with 0256 works fine, but reading with 0256 doesn't and I figured this should be made consistent.