### PR TITLE
for discussion: use existing clock delta when applying kria reset

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -848,16 +848,17 @@ void clock_kria(uint8_t phase) {
 
 		if(pos_reset) {
 			clock_count = 0;
+			u64 current_tick = get_ticks();
 			for(int i1=0;i1<KRIA_NUM_TRACKS;i1++)
 			for(int i2=0;i2<KRIA_NUM_PARAMS;i2++) {
 				pos[i1][i2] = k.p[k.pattern].t[i1].lend[i2];
 				pos_mul[i1][i2] = k.p[k.pattern].t[i1].tmul[i2];
+				last_ticks[i1] = current_tick - clock_deltas[i1];
 			}
 			cue_count = 0;
 			cue_sub_count = 0;
 			pos_reset = false;
 		}
-
 
 		for ( uint8_t i=0; i<KRIA_NUM_TRACKS; i++ )
 		{


### PR DESCRIPTION
Kria measures the clock frequency to calculate gate durations and ratchet timing relative to the clock. When an incoming external clock stops completely, then starts again, the measurement code needs two rising edges to measure the clock rate, causing a different note duration for the first note played. 
This patch, when resetting the Kria playhead, replaces the previous measured edge time t_{-1} with t_{0} - \delta, where t_{0} is the current time and \delta is the existing edge measurement t_{-1} - t_{-2} , causing the next clock measurement to evaluate to t_{0} - (t_{0} - \delta) = \delta.

This resolves the issue described [here](https://llllllll.co/t/ansible-development-and-beta-firmware-discussion/23118/219), using Pamela's New Workout to clock / reset Kria in sync with other modules. Since this potentially affects trigger ratcheting as well, I suspect this may also be a factor in issue #37, also reported when clocking / resetting Kria with Pam's. @fourhexagons if you would like to test this patch, there is a build posted [here](https://llllllll.co/t/ansible-development-and-beta-firmware-discussion/23118/242).

This change does however represent a change to behavior that users may be relying on. Specifically, when modulating the external clock frequency or changing Ansible's main internal clock rate, duration and ratchet timings will now lag by one clock cycle after a reset pulse, rather than tracking the clock edge-for-edge. Note that the same code will run when changing the active pattern sets `pos_reset = true`, so this could affect behavior when e.g. metasequencing and changing the Ansible main clock performatively. Another flag could be used to avoid this, but then stopping the clock, changing the pattern, and starting the clock would be affected by the same issue that this patch is intended to address.