### PR TITLE
KR.DIR: fix bounds checking, 0 for all tracks

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -1437,6 +1437,8 @@ void ii_kria(uint8_t *d, uint8_t l) {
 			}
 			break;
 		case II_KR_DIR + II_GET:
+			if ( d[1] <= 0
+			  || d[1] > KRIA_NUM_TRACKS) break;
 			if (l >= 2) {
 				ii_tx_queue(k.p[k.pattern].t[d[1] - 1].direction);
 			}

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -1423,7 +1423,16 @@ void ii_kria(uint8_t *d, uint8_t l) {
 			break;
 		}
 		case II_KR_DIR:
-			if (l >= 3 && d[2] <= krDirRandom) {
+			if ( d[1] < 0
+			  || d[1] > KRIA_NUM_TRACKS
+			  || d[2] < 0
+			  || d[2] > krDirRandom) break;
+			if ( d[1] == 0 ) {
+				for ( int i=0; i<KRIA_NUM_TRACKS; i++) {
+					k.p[k.pattern].t[i].direction = d[2];
+				}
+			}
+			else {
 				k.p[k.pattern].t[d[1]-1].direction = d[2];
 			}
 			break;


### PR DESCRIPTION
It's useful for the `KR.DIR` op to simultaneously affect all tracks when you pass track 0, but this wasn't implemented. Also found that I wasn't bounds checking properly, so weird Teletype arguments to this op could probably corrupt Kria state.