### PR TITLE
fix typo breaking USB backup

### DIFF
--- a/src/ansible_preset_docdef.c
+++ b/src/ansible_preset_docdef.c
@@ -92,7 +92,7 @@ json_docdef_t ansible_meta_docdefs[] = {
 				.write = json_write_object,
 				.state = &ansible_app_object_state[0],
 				.params = &((json_read_object_params_t) {
-					.docdef_ct = 7,
+					.docdef_ct = 4,
 					.docdefs = ((json_docdef_t[]) {
 						{
 							.name = "active",


### PR DESCRIPTION
Goofed this and it makes it impossible to save a JSON backup to disk in 3.0.0. Should maybe do a patch release for this, I'll post a build on the forum later today.