### PR TITLE
kria: can lock which pattern is being edited in meta mode

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -36,6 +36,7 @@ bool follower_select;
 bool mod_follower;
 uint8_t follower;
 bool kriaAltModeBlink; // flag gets flipped for the blinking
+bool kriaMetaLockBlink;
 
 u8 grid_varibrightness = 16;
 u8 key_count = 0;
@@ -563,13 +564,17 @@ uint8_t meta_pos;
 uint8_t meta_count;
 uint8_t meta_next;
 uint8_t meta_edit;
+bool meta_lock;
+uint8_t edit_pattern;
 
 static void kria_off(void* o);
 static void kria_blink_off(void* o);
 static void kria_rpt_off(void* o);
 static void kria_alt_mode_blink(void* o);
 static void kria_set_alt_blink_timer(kria_modes_t mode);
+static void kria_meta_lock_blink(void* o);
 softTimer_t altBlinkTimer = { .next = NULL, .prev = NULL };
+softTimer_t metaLockBlinkTimer = { .next = NULL, .prev = NULL };
 bool k_mode_is_alt = false;
 
 bool kria_next_step(uint8_t t, uint8_t p);
@@ -631,6 +636,7 @@ void default_kria() {
 		k.p[i1] = k.p[0];
 
 	k.pattern = 0;
+	edit_pattern = k.pattern;
 
 	k.meta_start = 0;
 	k.meta_end = 3;
@@ -659,6 +665,7 @@ void init_kria() {
 	preset = f.kria_state.preset;
 
 	k.pattern = f.kria_state.k[preset].pattern;
+	edit_pattern = k.pattern;
 
 	k = f.kria_state.k[preset];
 
@@ -709,17 +716,18 @@ void grid_keytimer_kria(uint8_t held_key) {
 		if(held_key < 16) {
 			memcpy((void *)&k.p[held_key], &k.p[k.pattern], sizeof(k.p[k.pattern]));
 			k.pattern = held_key;
+			if (!meta_lock) edit_pattern = k.pattern;
 			// pos_reset = true;
 		}
 		break;
 	case mRpt:
 		if(held_key < 16) {
-			k.p[k.pattern].t[track].rpt[held_key] -= 1;
-			k.p[k.pattern].t[track].rptBits[held_key] = ~(0xff << k.p[k.pattern].t[track].rpt[held_key]);
+			k.p[edit_pattern].t[track].rpt[held_key] -= 1;
+			k.p[edit_pattern].t[track].rptBits[held_key] = ~(0xff << k.p[edit_pattern].t[track].rpt[held_key]);
 		}
 		else if(held_key >= R6 && held_key < R7) {
-			k.p[k.pattern].t[track].rpt[held_key - R6] = 1;
-			k.p[k.pattern].t[track].rptBits[held_key - R6] = 1;
+			k.p[edit_pattern].t[track].rpt[held_key - R6] = 1;
+			k.p[edit_pattern].t[track].rptBits[held_key - R6] = 1;
 		}
 		break;
 	default:
@@ -1043,8 +1051,15 @@ static void kria_alt_mode_blink(void* o) {
 	monomeFrameDirty++;
 }
 
+static void kria_meta_lock_blink(void* o) {
+	kriaMetaLockBlink = !kriaMetaLockBlink;
+	monomeFrameDirty++;
+}
+
+
 void change_pattern(uint8_t x) {
 	k.pattern = x;
+	if (!meta_lock) edit_pattern = k.pattern;
 	pos_reset = true;
 	calc_scale(k.p[k.pattern].scale);
 }
@@ -1539,57 +1554,57 @@ static void kria_set_tmul(uint8_t track, kria_modes_t mode, uint8_t new_tmul) {
 	case 1:
 		if (note_div_sync) {
 			if (mode == mTr || mode == mNote) {
-				k.p[k.pattern].t[track].tmul[mTr] = new_tmul;
-				k.p[k.pattern].t[track].tmul[mNote] = new_tmul;
+				k.p[edit_pattern].t[track].tmul[mTr] = new_tmul;
+				k.p[edit_pattern].t[track].tmul[mNote] = new_tmul;
 			} else {
-				k.p[k.pattern].t[track].tmul[mRpt] = new_tmul;
-				k.p[k.pattern].t[track].tmul[mAltNote] = new_tmul;
-				k.p[k.pattern].t[track].tmul[mOct] = new_tmul;
-				k.p[k.pattern].t[track].tmul[mGlide] = new_tmul;
-				k.p[k.pattern].t[track].tmul[mDur] = new_tmul;
+				k.p[edit_pattern].t[track].tmul[mRpt] = new_tmul;
+				k.p[edit_pattern].t[track].tmul[mAltNote] = new_tmul;
+				k.p[edit_pattern].t[track].tmul[mOct] = new_tmul;
+				k.p[edit_pattern].t[track].tmul[mGlide] = new_tmul;
+				k.p[edit_pattern].t[track].tmul[mDur] = new_tmul;
 			}
 		} else {
-			k.p[k.pattern].t[track].tmul[mTr] = new_tmul;
-			k.p[k.pattern].t[track].tmul[mNote] = new_tmul;
-			k.p[k.pattern].t[track].tmul[mRpt] = new_tmul;
-			k.p[k.pattern].t[track].tmul[mAltNote] = new_tmul;
-			k.p[k.pattern].t[track].tmul[mOct] = new_tmul;
-			k.p[k.pattern].t[track].tmul[mGlide] = new_tmul;
-			k.p[k.pattern].t[track].tmul[mDur] = new_tmul;
+			k.p[edit_pattern].t[track].tmul[mTr] = new_tmul;
+			k.p[edit_pattern].t[track].tmul[mNote] = new_tmul;
+			k.p[edit_pattern].t[track].tmul[mRpt] = new_tmul;
+			k.p[edit_pattern].t[track].tmul[mAltNote] = new_tmul;
+			k.p[edit_pattern].t[track].tmul[mOct] = new_tmul;
+			k.p[edit_pattern].t[track].tmul[mGlide] = new_tmul;
+			k.p[edit_pattern].t[track].tmul[mDur] = new_tmul;
 		}
 		break;
 	case 2:
 		for (uint8_t i = 0; i < 4; i++) {
 			if (note_div_sync) {
 				if (mode == mTr || mode == mNote) {
-					k.p[k.pattern].t[i].tmul[mTr] = new_tmul;
-					k.p[k.pattern].t[i].tmul[mNote] = new_tmul;
+					k.p[edit_pattern].t[i].tmul[mTr] = new_tmul;
+					k.p[edit_pattern].t[i].tmul[mNote] = new_tmul;
 				} else {
-					k.p[k.pattern].t[i].tmul[mRpt] = new_tmul;
-					k.p[k.pattern].t[i].tmul[mAltNote] = new_tmul;
-					k.p[k.pattern].t[i].tmul[mOct] = new_tmul;
-					k.p[k.pattern].t[i].tmul[mGlide] = new_tmul;
-					k.p[k.pattern].t[i].tmul[mDur] = new_tmul;
+					k.p[edit_pattern].t[i].tmul[mRpt] = new_tmul;
+					k.p[edit_pattern].t[i].tmul[mAltNote] = new_tmul;
+					k.p[edit_pattern].t[i].tmul[mOct] = new_tmul;
+					k.p[edit_pattern].t[i].tmul[mGlide] = new_tmul;
+					k.p[edit_pattern].t[i].tmul[mDur] = new_tmul;
 				}
 			} else {
-				k.p[k.pattern].t[i].tmul[mTr] = new_tmul;
-				k.p[k.pattern].t[i].tmul[mNote] = new_tmul;
-				k.p[k.pattern].t[i].tmul[mRpt] = new_tmul;
-				k.p[k.pattern].t[i].tmul[mAltNote] = new_tmul;
-				k.p[k.pattern].t[i].tmul[mOct] = new_tmul;
-				k.p[k.pattern].t[i].tmul[mGlide] = new_tmul;
-				k.p[k.pattern].t[i].tmul[mDur] = new_tmul;
+				k.p[edit_pattern].t[i].tmul[mTr] = new_tmul;
+				k.p[edit_pattern].t[i].tmul[mNote] = new_tmul;
+				k.p[edit_pattern].t[i].tmul[mRpt] = new_tmul;
+				k.p[edit_pattern].t[i].tmul[mAltNote] = new_tmul;
+				k.p[edit_pattern].t[i].tmul[mOct] = new_tmul;
+				k.p[edit_pattern].t[i].tmul[mGlide] = new_tmul;
+				k.p[edit_pattern].t[i].tmul[mDur] = new_tmul;
 			}
 		}
 		break;
 	default:
-		k.p[k.pattern].t[track].tmul[mode] = new_tmul;
+		k.p[edit_pattern].t[track].tmul[mode] = new_tmul;
 		if (note_div_sync) {
 			if (mode == mTr) {
-				k.p[k.pattern].t[track].tmul[mNote] = new_tmul;
+				k.p[edit_pattern].t[track].tmul[mNote] = new_tmul;
 			}
 			if (mode == mNote) {
-				k.p[k.pattern].t[track].tmul[mTr] = new_tmul;
+				k.p[edit_pattern].t[track].tmul[mTr] = new_tmul;
 			}
 		}
 		break;
@@ -2073,7 +2088,7 @@ void handler_KriaGridKey(s32 data) {
 				switch(k_mod_mode) {
 				case modNone:
 					if(z) {
-						k.p[k.pattern].t[y].tr[x] ^= 1;
+						k.p[edit_pattern].t[y].tr[x] ^= 1;
 						monomeFrameDirty++;
 					}
 					break;
@@ -2101,7 +2116,7 @@ void handler_KriaGridKey(s32 data) {
 
 						if(loop_count == 0) {
 							if(loop_last == -1) {
-								if(loop_first == k.p[k.pattern].t[loop_edit].lstart[mTr]) {
+								if(loop_first == k.p[edit_pattern].t[loop_edit].lstart[mTr]) {
 									update_loop_start(loop_edit, loop_first, mTr);
 									update_loop_end(loop_edit, loop_first, mTr);
 									if (note_sync) {
@@ -2127,7 +2142,7 @@ void handler_KriaGridKey(s32 data) {
 					break;
 				case modProb:
 					if(z && y > 1 && y < 6) {
-						k.p[k.pattern].t[track].p[mTr][x] = 5 - y;
+						k.p[edit_pattern].t[track].p[mTr][x] = 5 - y;
 						monomeFrameDirty++;
 					}
 					break;
@@ -2140,15 +2155,15 @@ void handler_KriaGridKey(s32 data) {
 				case modNone:
 					if(z) {
 						if(note_sync) {
-							if(k.p[k.pattern].t[track].tr[x] && k.p[k.pattern].t[track].note[x] == 6-y)
-								k.p[k.pattern].t[track].tr[x] = 0;
+							if(k.p[edit_pattern].t[track].tr[x] && k.p[edit_pattern].t[track].note[x] == 6-y)
+								k.p[edit_pattern].t[track].tr[x] = 0;
 							else {
-								k.p[k.pattern].t[track].tr[x] = 1;
-								k.p[k.pattern].t[track].note[x] = 6-y;
+								k.p[edit_pattern].t[track].tr[x] = 1;
+								k.p[edit_pattern].t[track].note[x] = 6-y;
 							}
 						}
 						else
-							k.p[k.pattern].t[track].note[x] = 6-y;
+							k.p[edit_pattern].t[track].note[x] = 6-y;
 						monomeFrameDirty++;
 					}
 					break;
@@ -2175,7 +2190,7 @@ void handler_KriaGridKey(s32 data) {
 
 						if(loop_count == 0) {
 							if(loop_last == -1) {
-								if(loop_first == k.p[k.pattern].t[track].lstart[mNote]) {
+								if(loop_first == k.p[edit_pattern].t[track].lstart[mNote]) {
 									update_loop_start(track, loop_first, mNote);
 									update_loop_end(track, loop_first, mNote);
 									if (note_sync) {
@@ -2201,7 +2216,7 @@ void handler_KriaGridKey(s32 data) {
 					break;
 				case modProb:
 					if(z && y > 1 && y < 6) {
-						k.p[k.pattern].t[track].p[mNote][x] = 5 - y;
+						k.p[edit_pattern].t[track].p[mNote][x] = 5 - y;
 						monomeFrameDirty++;
 					}
 					break;
@@ -2214,12 +2229,12 @@ void handler_KriaGridKey(s32 data) {
 					if(z) {
 						if(y==0) {
 							if (x <= 5) {
-								k.p[k.pattern].t[track].octshift = x;
+								k.p[edit_pattern].t[track].octshift = x;
 							}
 						}
 						else {
 							uint8_t abs_oct = 6 - y;
-							k.p[k.pattern].t[track].oct[x] = (int)abs_oct - (int)k.p[k.pattern].t[track].octshift;
+							k.p[edit_pattern].t[track].oct[x] = (int)abs_oct - (int)k.p[edit_pattern].t[track].octshift;
 						}
 						monomeFrameDirty++;
 					}
@@ -2243,7 +2258,7 @@ void handler_KriaGridKey(s32 data) {
 
 						if(loop_count == 0) {
 							if(loop_last == -1) {
-								if(loop_first == k.p[k.pattern].t[track].lstart[mOct]) {
+								if(loop_first == k.p[edit_pattern].t[track].lstart[mOct]) {
 									update_loop_start(track, loop_first, mOct);
 									update_loop_end(track, loop_first, mOct);
 								}
@@ -2262,7 +2277,7 @@ void handler_KriaGridKey(s32 data) {
 					break;
 				case modProb:
 					if(z && y > 1 && y < 6) {
-						k.p[k.pattern].t[track].p[mOct][x] = 5 - y;
+						k.p[edit_pattern].t[track].p[mOct][x] = 5 - y;
 						monomeFrameDirty++;
 					}
 					break;
@@ -2274,9 +2289,9 @@ void handler_KriaGridKey(s32 data) {
 				case modNone:
 					if(z) {
 						if(y==0)
-							k.p[k.pattern].t[track].dur_mul = x+1;
+							k.p[edit_pattern].t[track].dur_mul = x+1;
 						else
-							k.p[k.pattern].t[track].dur[x] = y-1;
+							k.p[edit_pattern].t[track].dur[x] = y-1;
 						monomeFrameDirty++;
 					}
 					break;
@@ -2300,7 +2315,7 @@ void handler_KriaGridKey(s32 data) {
 
 							if(loop_count == 0) {
 								if(loop_last == -1) {
-									if(loop_first == k.p[k.pattern].t[track].lstart[mDur]) {
+									if(loop_first == k.p[edit_pattern].t[track].lstart[mDur]) {
 										update_loop_start(track, loop_first, mDur);
 										update_loop_end(track, loop_first, mDur);
 									}
@@ -2320,7 +2335,7 @@ void handler_KriaGridKey(s32 data) {
 					break;
 				case modProb:
 					if(z && y > 1 && y < 6) {
-						k.p[k.pattern].t[track].p[mDur][x] = 5 - y;
+						k.p[edit_pattern].t[track].p[mDur][x] = 5 - y;
 						monomeFrameDirty++;
 					}
 					break;
@@ -2332,28 +2347,28 @@ void handler_KriaGridKey(s32 data) {
 				case modNone:
 					if (z) {
 						if ( y == 0 ) {
-							if (k.p[k.pattern].t[track].rpt[x] < 5) {
-								k.p[k.pattern].t[track].rpt[x]++;
+							if (k.p[edit_pattern].t[track].rpt[x] < 5) {
+								k.p[edit_pattern].t[track].rpt[x]++;
 							}
 							else {
-								k.p[k.pattern].t[track].rpt[x] = 5;
+								k.p[edit_pattern].t[track].rpt[x] = 5;
 							}
 						}
 						if ( y > 0 && y < 6 ) {
-					  		uint8_t rptBits = k.p[k.pattern].t[track].rptBits[x] ^ (1 << (5 - y));
+					  		uint8_t rptBits = k.p[edit_pattern].t[track].rptBits[x] ^ (1 << (5 - y));
 							uint8_t rpt = 1;
-							k.p[k.pattern].t[track].rptBits[x] = rptBits;
+							k.p[edit_pattern].t[track].rptBits[x] = rptBits;
 							while (rptBits >>= 1) rpt++;
-							k.p[k.pattern].t[track].rpt[x] = rpt;
+							k.p[edit_pattern].t[track].rpt[x] = rpt;
 
 							monomeFrameDirty++;
 						}
 						if ( y == 6 ) {
-							if (k.p[k.pattern].t[track].rpt[x] > 1) {
-								k.p[k.pattern].t[track].rpt[x]--;
+							if (k.p[edit_pattern].t[track].rpt[x] > 1) {
+								k.p[edit_pattern].t[track].rpt[x]--;
 							}
 							else {
-								k.p[k.pattern].t[track].rpt[x] = 1;
+								k.p[edit_pattern].t[track].rpt[x] = 1;
 							}
 						}
 					}
@@ -2369,7 +2384,7 @@ void handler_KriaGridKey(s32 data) {
 							loop_last = x;
 							if(loop_last == loop_first) {
 								vrange_last = y;
-								k.p[k.pattern].t[track].rpt[x] = 6 - y;
+								k.p[edit_pattern].t[track].rpt[x] = 6 - y;
 							}
 							else {
 								update_loop_start(track, loop_first, mRpt);
@@ -2384,9 +2399,9 @@ void handler_KriaGridKey(s32 data) {
 
 						if(loop_count == 0) {
 							if(loop_last == -1) {
-								if(loop_first == k.p[k.pattern].t[track].lstart[mRpt]) {
+								if(loop_first == k.p[edit_pattern].t[track].lstart[mRpt]) {
 									if(vrange_last == -1 && x == loop_first) {
-										k.p[k.pattern].t[track].rpt[x] = 6 - y;
+										k.p[edit_pattern].t[track].rpt[x] = 6 - y;
 									}
 									else {
 										update_loop_start(track, loop_first, mRpt);
@@ -2409,7 +2424,7 @@ void handler_KriaGridKey(s32 data) {
 					break;
 				case modProb:
 					if(z && y > 1 && y < 6) {
-						k.p[k.pattern].t[track].p[mRpt][x] = 5 - y;
+						k.p[edit_pattern].t[track].p[mRpt][x] = 5 - y;
 						monomeFrameDirty++;
 					}
 					break;
@@ -2420,7 +2435,7 @@ void handler_KriaGridKey(s32 data) {
 				switch(k_mod_mode) {
 				case modNone:
 					if(z) {
-						k.p[k.pattern].t[track].alt_note[x] = 6-y;
+						k.p[edit_pattern].t[track].alt_note[x] = 6-y;
 						monomeFrameDirty++;
 					}
 					break;
@@ -2443,7 +2458,7 @@ void handler_KriaGridKey(s32 data) {
 
 						if(loop_count == 0) {
 							if(loop_last == -1) {
-								if(loop_first == k.p[k.pattern].t[track].lstart[mAltNote]) {
+								if(loop_first == k.p[edit_pattern].t[track].lstart[mAltNote]) {
 									update_loop_start(track, loop_first, mAltNote);
 									update_loop_end(track, loop_first, mAltNote);
 								}
@@ -2462,7 +2477,7 @@ void handler_KriaGridKey(s32 data) {
 					break;
 				case modProb:
 					if(z && y > 1 && y < 6) {
-						k.p[k.pattern].t[track].p[mAltNote][x] = 5 - y;
+						k.p[edit_pattern].t[track].p[mAltNote][x] = 5 - y;
 						monomeFrameDirty++;
 					}
 					break;
@@ -2474,7 +2489,7 @@ void handler_KriaGridKey(s32 data) {
 				case modNone:
 					if(z) {
 						// if(y>2)
-							k.p[k.pattern].t[track].glide[x] = 6-y;
+							k.p[edit_pattern].t[track].glide[x] = 6-y;
 						monomeFrameDirty++;
 					}
 					break;
@@ -2497,7 +2512,7 @@ void handler_KriaGridKey(s32 data) {
 
 						if(loop_count == 0) {
 							if(loop_last == -1) {
-								if(loop_first == k.p[k.pattern].t[track].lstart[mGlide]) {
+								if(loop_first == k.p[edit_pattern].t[track].lstart[mGlide]) {
 									update_loop_start(track, loop_first, mGlide);
 									update_loop_end(track, loop_first, mGlide);
 								}
@@ -2516,7 +2531,7 @@ void handler_KriaGridKey(s32 data) {
 					break;
 				case modProb:
 					if(z && y > 1 && y < 6) {
-						k.p[k.pattern].t[track].p[mGlide][x] = 5 - y;
+						k.p[edit_pattern].t[track].p[mGlide][x] = 5 - y;
 						monomeFrameDirty++;
 					}
 					break;
@@ -2527,18 +2542,18 @@ void handler_KriaGridKey(s32 data) {
 				if(z) {
 					if ( y < 4 && x <= 7 ) {
 						if (x == 0){
-						        k.p[k.pattern].t[y].tt_clocked = !k.p[k.pattern].t[y].tt_clocked;
+						        k.p[edit_pattern].t[y].tt_clocked = !k.p[edit_pattern].t[y].tt_clocked;
 						}
 						if (x == 1) {
-							k.p[k.pattern].t[y].trigger_clocked = !k.p[k.pattern].t[y].trigger_clocked;
+							k.p[edit_pattern].t[y].trigger_clocked = !k.p[edit_pattern].t[y].trigger_clocked;
 						}
 						if (x >= 3 && x <= 7) {
-							k.p[k.pattern].t[y].direction = x - 3;
+							k.p[edit_pattern].t[y].direction = x - 3;
 						}
 					}
 					else if(x < 8) {
 						if(y > 4) {
-							k.p[k.pattern].scale = (y - 5) * 8 + x;
+							k.p[edit_pattern].scale = (y - 5) * 8 + x;
 							for (uint8_t i = 0; i < 8; i++) {
 								scale_adj[i] = 0;
 							}
@@ -2547,18 +2562,18 @@ void handler_KriaGridKey(s32 data) {
 					else {
 						uint8_t i;
 						for (i = 0; i < key_count; i++) {
-							if (held_keys[i] == 16*y + scale_data[k.p[k.pattern].scale][6 - y] + 8) {
-								scale_adj[6 - y] = x - 8 - scale_data[k.p[k.pattern].scale][6 - y];
+							if (held_keys[i] == 16*y + scale_data[k.p[edit_pattern].scale][6 - y] + 8) {
+								scale_adj[6 - y] = x - 8 - scale_data[k.p[edit_pattern].scale][6 - y];
 								break;
 							}
 						}
 						if (i == key_count) {
-							scale_data[k.p[k.pattern].scale][6-y] = x-8;
+							scale_data[k.p[edit_pattern].scale][6-y] = x-8;
 							scale_adj[6 - y] = 0;
 						}
 					}
 
-					calc_scale(k.p[k.pattern].scale);
+					calc_scale(k.p[edit_pattern].scale);
 
 					monomeFrameDirty++;
 				}
@@ -2606,6 +2621,7 @@ void handler_KriaGridKey(s32 data) {
 				else if(z && y == 6) {
 					if(cue) {
 						meta ^= 1;
+						if (!meta) meta_lock = false;
 					}
 					else {
 						k.meta_steps[meta_edit] = x;
@@ -2619,6 +2635,23 @@ void handler_KriaGridKey(s32 data) {
 					default:
 						cue_steps = x;
 						break;
+					}
+				}
+				else if(z && y == 0) {
+					if (cue) {
+						if (meta) {
+							if (meta_lock && x == edit_pattern) {
+							    meta_lock = false;
+							    timer_remove( &metaLockBlinkTimer );
+							}
+							else {
+								edit_pattern = x;
+								if (!meta_lock) {
+									timer_add( &metaLockBlinkTimer, 100, &kria_meta_lock_blink, NULL );
+									meta_lock = true;
+								}
+							}
+						}
 					}
 				}
 				monomeFrameDirty++;
@@ -2679,50 +2712,54 @@ static void update_meta_end(u8 x) {
 static void adjust_loop_start(u8 t, u8 x, u8 m) {
 	s8 temp;
 
-	temp = pos[t][m] - k.p[k.pattern].t[t].lstart[m] + x;
-	if(temp < 0) temp += 16;
-	else if(temp > 15) temp -= 16;
-	pos[t][m] = temp;
+	if (!meta_lock || edit_pattern == k.pattern) {
+		temp = pos[t][m] - k.p[k.pattern].t[t].lstart[m] + x;
+		if(temp < 0) temp += 16;
+		else if(temp > 15) temp -= 16;
+		pos[t][m] = temp;
+	}
 
-	k.p[k.pattern].t[t].lstart[m] = x;
-	temp = x + k.p[k.pattern].t[t].llen[m]-1;
+	k.p[edit_pattern].t[t].lstart[m] = x;
+	temp = x + k.p[edit_pattern].t[t].llen[m]-1;
 	if(temp > 15) {
-		k.p[k.pattern].t[t].lend[m] = temp - 16;
-		k.p[k.pattern].t[t].lswap[m] = 1;
+		k.p[edit_pattern].t[t].lend[m] = temp - 16;
+		k.p[edit_pattern].t[t].lswap[m] = 1;
 	}
 	else {
-		k.p[k.pattern].t[t].lend[m] = temp;
-		k.p[k.pattern].t[t].lswap[m] = 0;
+		k.p[edit_pattern].t[t].lend[m] = temp;
+		k.p[edit_pattern].t[t].lswap[m] = 0;
 	}
 }
 
 static void adjust_loop_end(u8 t, u8 x, u8 m) {
 	s8 temp;
 
-	k.p[k.pattern].t[t].lend[m] = x;
-	temp = k.p[k.pattern].t[t].lend[m] - k.p[k.pattern].t[t].lstart[m];
+	k.p[edit_pattern].t[t].lend[m] = x;
+	temp = k.p[edit_pattern].t[t].lend[m] - k.p[edit_pattern].t[t].lstart[m];
 	if(temp < 0) {
-		k.p[k.pattern].t[t].llen[m] = temp + 17;
-		k.p[k.pattern].t[t].lswap[m] = 1;
+		k.p[edit_pattern].t[t].llen[m] = temp + 17;
+		k.p[edit_pattern].t[t].lswap[m] = 1;
 	}
 	else {
-		k.p[k.pattern].t[t].llen[m] = temp+1;
-		k.p[k.pattern].t[t].lswap[m] = 0;
+		k.p[edit_pattern].t[t].llen[m] = temp+1;
+		k.p[edit_pattern].t[t].lswap[m] = 0;
 	}
 
-	temp = pos[t][m];
-	if(k.p[k.pattern].t[t].lswap[m]) {
-		if(temp < k.p[k.pattern].t[t].lstart[m] && temp > k.p[k.pattern].t[t].lend[m])
-			pos[t][m] = k.p[k.pattern].t[t].lstart[m];
-	}
-	else {
-		if(temp < k.p[k.pattern].t[t].lstart[m] || temp > k.p[k.pattern].t[t].lend[m])
-			pos[t][m] = k.p[k.pattern].t[t].lstart[m];
+	if (!meta_lock || edit_pattern == k.pattern) {
+		temp = pos[t][m];
+		if(k.p[k.pattern].t[t].lswap[m]) {
+			if(temp < k.p[k.pattern].t[t].lstart[m] && temp > k.p[k.pattern].t[t].lend[m])
+				pos[t][m] = k.p[k.pattern].t[t].lstart[m];
+		}
+		else {
+			if(temp < k.p[k.pattern].t[t].lstart[m] || temp > k.p[k.pattern].t[t].lend[m])
+				pos[t][m] = k.p[k.pattern].t[t].lstart[m];
+		}
 	}
 }
 
 static void adjust_loop_len(u8 t, u8 x, u8 m) {
-	adjust_loop_end(t, (x - 1 + k.p[k.pattern].t[t].lstart[m]) & 0xf, m);
+	adjust_loop_end(t, (x - 1 + k.p[edit_pattern].t[t].lstart[m]) & 0xf, m);
 }
 
 static void update_loop_start(u8 t, u8 x, u8 m) {
@@ -2877,7 +2914,7 @@ void refresh_kria(void) {
 	monomeLedBuffer[R7 + 11] = L0;
 	monomeLedBuffer[R7 + 12] = L0;
 	monomeLedBuffer[R7 + 14] = L0;
-	monomeLedBuffer[R7 + 15] = L0;
+	monomeLedBuffer[R7 + 15] = (meta && meta_lock && kriaMetaLockBlink) ? L1 : L0;
 
 	for ( uint8_t i=0; i<4; i++ )
 	{
@@ -2912,7 +2949,12 @@ void refresh_kria(void) {
 		activeModeIndex = R7+0; break;
 	}
 
-	monomeLedBuffer[activeModeIndex] = (k_mode_is_alt && kriaAltModeBlink) ? L1 : L2;
+	if (k_mode == mPattern) {
+		monomeLedBuffer[activeModeIndex] = (meta && meta_lock && kriaMetaLockBlink) ? L1 : L2;
+	}
+	else {
+		monomeLedBuffer[activeModeIndex] = (k_mode_is_alt && kriaAltModeBlink) ? L1 : L2;
+	}
 
 
 	if (refresh_kria_mod()) return;
@@ -2955,14 +2997,14 @@ bool refresh_kria_mod(void) {
 	case modTime:
 		monomeLedBuffer[R7 + 11] = L1;
 		memset(monomeLedBuffer + R1, 3, 16);
-		monomeLedBuffer[R1 + k.p[k.pattern].t[track].tmul[k_mode] - 1] = L1;
+		monomeLedBuffer[R1 + k.p[edit_pattern].t[track].tmul[k_mode] - 1] = L1;
 		return true;
 	case modProb:
 		monomeLedBuffer[R7 + 12] = L1;
 		memset(monomeLedBuffer + R5, 3, 16);
 		for(uint8_t i=0;i<16;i++) {
-			if(k.p[k.pattern].t[track].p[k_mode][i]) {
-				monomeLedBuffer[(5 - k.p[k.pattern].t[track].p[k_mode][i]) * 16 + i] = i == pos[track][k_mode] ? 10 : 6;
+			if(k.p[edit_pattern].t[track].p[k_mode][i]) {
+				monomeLedBuffer[(5 - k.p[edit_pattern].t[track].p[k_mode][i]) * 16 + i] = i == pos[track][k_mode] ? 10 : 6;
 			}
 		}
 		return true;
@@ -2975,22 +3017,24 @@ void refresh_kria_tr(void) {
 	// steps
 	for(uint8_t i=0;i<4;i++) {
 		for(uint8_t j=0;j<16;j++) {
-			if(k.p[k.pattern].t[i].tr[j])
+			if(k.p[edit_pattern].t[i].tr[j])
 				monomeLedBuffer[i*16 + j] = 3;
 		}
 		// playhead
 		// if(tr[i2])
-		monomeLedBuffer[i*16 + pos[i][mTr]] += 4;
+		if (!meta_lock || edit_pattern == k.pattern) {
+			monomeLedBuffer[i*16 + pos[i][mTr]] += 4;
+		}
 	}
 
 	// loop highlight
 	for(uint8_t i=0;i<4;i++) {
-		if(k.p[k.pattern].t[i].lswap[mTr]) {
-			for(uint8_t j=0;j<k.p[k.pattern].t[i].llen[mTr];j++)
-				monomeLedBuffer[i*16 + (j+k.p[k.pattern].t[i].lstart[mTr])%16] += 2 + (k_mod_mode == modLoop);
+		if(k.p[edit_pattern].t[i].lswap[mTr]) {
+			for(uint8_t j=0;j<k.p[edit_pattern].t[i].llen[mTr];j++)
+				monomeLedBuffer[i*16 + (j+k.p[edit_pattern].t[i].lstart[mTr])%16] += 2 + (k_mod_mode == modLoop);
 		}
 		else {
-			for(uint8_t j=k.p[k.pattern].t[i].lstart[mTr];j<=k.p[k.pattern].t[i].lend[mTr];j++)
+			for(uint8_t j=k.p[edit_pattern].t[i].lstart[mTr];j<=k.p[edit_pattern].t[i].lend[mTr];j++)
 				monomeLedBuffer[i*16 + j] += 2 + (k_mod_mode == modLoop);
 		}
 	}
@@ -2998,40 +3042,42 @@ void refresh_kria_tr(void) {
 
 void refresh_kria_note(bool isAlt) {
 	kria_modes_t noteMode = isAlt ? mAltNote : mNote;
-	u8 (*notesArray)[16] = isAlt ? &k.p[k.pattern].t[track].alt_note : &k.p[k.pattern].t[track].note;
+	u8 (*notesArray)[16] = isAlt ? &k.p[edit_pattern].t[track].alt_note : &k.p[edit_pattern].t[track].note;
 
 	if(!isAlt && note_sync) {
 		for(uint8_t i=0;i<16;i++)
 			monomeLedBuffer[i + (6 - (*notesArray)[i] ) * 16] =
-				k.p[k.pattern].t[track].tr[i] * 3;
+				k.p[edit_pattern].t[track].tr[i] * 3;
 	}
 	else {
 		for(uint8_t i=0;i<16;i++)
 			monomeLedBuffer[i + (6 - (*notesArray)[i] ) * 16] = 3;
 	}
 
-	monomeLedBuffer[pos[track][noteMode] + (6-(*notesArray)[pos[track][noteMode]])*16] += 4;
+	if (!meta_lock || edit_pattern == k.pattern) {
+		monomeLedBuffer[pos[track][noteMode] + (6-(*notesArray)[pos[track][noteMode]])*16] += 4;
+	}
 
-	if(k.p[k.pattern].t[track].lswap[noteMode]) {
-		for(uint8_t i=0;i<k.p[k.pattern].t[track].llen[noteMode];i++) {
-			uint8_t x = (k.p[k.pattern].t[track].lstart[noteMode] + i) % 16;
+	if(k.p[edit_pattern].t[track].lswap[noteMode]) {
+		for(uint8_t i=0;i<k.p[edit_pattern].t[track].llen[noteMode];i++) {
+			uint8_t x = (k.p[edit_pattern].t[track].lstart[noteMode] + i) % 16;
 			uint8_t y = 6 - (*notesArray)[x];
 			monomeLedBuffer[16*y + x] += 3 + (k_mod_mode == modLoop)*2;
 		}
 	}
 	else {
-		for(uint8_t i=k.p[k.pattern].t[track].lstart[noteMode];i<=k.p[k.pattern].t[track].lend[noteMode];i++)
+		for(uint8_t i=k.p[edit_pattern].t[track].lstart[noteMode];i<=k.p[edit_pattern].t[track].lend[noteMode];i++)
 			monomeLedBuffer[i+(6-(*notesArray)[i])*16] += 3 + (k_mod_mode == modLoop)*2;
 	}
 }
 
 void refresh_kria_oct(void) {
 	memset(monomeLedBuffer, 2, 6);
-	monomeLedBuffer[R0+k.p[k.pattern].t[track].octshift] = L1;
+	monomeLedBuffer[R0+k.p[edit_pattern].t[track].octshift] = L1;
 
 	for(uint8_t i=0;i<16;i++) {
-		const uint8_t octshift = k.p[k.pattern].t[track].octshift;
-		const int8_t octsum = sum_clip(k.p[k.pattern].t[track].oct[i], (int)octshift, 5);
+		const uint8_t octshift = k.p[edit_pattern].t[track].octshift;
+		const int8_t octsum = sum_clip(k.p[edit_pattern].t[track].oct[i], (int)octshift, 5);
 
 		for(uint8_t j=0;j<=5;j++) {
 			if (octsum >= octshift) {
@@ -3042,8 +3088,8 @@ void refresh_kria_oct(void) {
 			}
 			monomeLedBuffer[R6-16*j+i] = grid_varibrightness < 16 ? L0 : 3;
 
-			if(k.p[k.pattern].t[track].lswap[mOct]) {
-				if((i < k.p[k.pattern].t[track].lstart[mOct]) && (i > k.p[k.pattern].t[track].lend[mOct])) {
+			if(k.p[edit_pattern].t[track].lswap[mOct]) {
+				if((i < k.p[edit_pattern].t[track].lstart[mOct]) && (i > k.p[edit_pattern].t[track].lend[mOct])) {
 					monomeLedBuffer[R6-16*j+i] -= 2;
 				}
 				else if ( k_mod_mode == modLoop ) {
@@ -3051,7 +3097,7 @@ void refresh_kria_oct(void) {
 				}
 			}
 			else {
-				if((i < k.p[k.pattern].t[track].lstart[mOct]) || (i > k.p[k.pattern].t[track].lend[mOct])) {
+				if((i < k.p[edit_pattern].t[track].lstart[mOct]) || (i > k.p[edit_pattern].t[track].lend[mOct])) {
 					monomeLedBuffer[R6-16*j+i] -= 2;
 				}
 				else if ( k_mod_mode == modLoop ) {
@@ -3060,20 +3106,23 @@ void refresh_kria_oct(void) {
 			}
 		}
 
-		if(i == pos[track][mOct]) {
-			monomeLedBuffer[R6 - octsum*16 + i] += 4;
+
+		if (!meta_lock || edit_pattern == k.pattern) {
+			if(i == pos[track][mOct]) {
+				monomeLedBuffer[R6 - octsum*16 + i] += 4;
+			}
 		}
 	}
 }
 
 void refresh_kria_dur(void) {
-	monomeLedBuffer[k.p[k.pattern].t[track].dur_mul - 1] = L1;
+	monomeLedBuffer[k.p[edit_pattern].t[track].dur_mul - 1] = L1;
 
 	for(uint8_t i=0;i<16;i++) {
-		for(uint8_t j=0;j<=k.p[k.pattern].t[track].dur[i];j++) {
+		for(uint8_t j=0;j<=k.p[edit_pattern].t[track].dur[i];j++) {
 			monomeLedBuffer[R1+16*j+i] = grid_varibrightness < 16 ? L0 : 3;
-			if(k.p[k.pattern].t[track].lswap[mDur]) {
-				if((i < k.p[k.pattern].t[track].lstart[mDur]) && (i > k.p[k.pattern].t[track].lend[mDur])) {
+			if(k.p[edit_pattern].t[track].lswap[mDur]) {
+				if((i < k.p[edit_pattern].t[track].lstart[mDur]) && (i > k.p[edit_pattern].t[track].lend[mDur])) {
 					monomeLedBuffer[R1+16*j+i] -= 2;
 				}
 				else if ( k_mod_mode == modLoop ) {
@@ -3081,7 +3130,7 @@ void refresh_kria_dur(void) {
 				}
 			}
 			else {
-				if((i < k.p[k.pattern].t[track].lstart[mDur]) || (i > k.p[k.pattern].t[track].lend[mDur])) {
+				if((i < k.p[edit_pattern].t[track].lstart[mDur]) || (i > k.p[edit_pattern].t[track].lend[mDur])) {
 					monomeLedBuffer[R1+16*j+i] -= 2;
 				}
 				else if ( k_mod_mode == modLoop ) {
@@ -3090,44 +3139,48 @@ void refresh_kria_dur(void) {
 			}
 		}
 
-		if(i == pos[track][mDur])
-			monomeLedBuffer[R1+i+16*k.p[k.pattern].t[track].dur[i]] += 4;
+		if (!meta_lock || edit_pattern == k.pattern) {
+			if(i == pos[track][mDur])
+				monomeLedBuffer[R1+i+16*k.p[k.pattern].t[track].dur[i]] += 4;
+		}
 	}
 }
 
 void refresh_kria_rpt(void) {
 	for ( uint8_t i=0; i<16; i++ ) {
-		uint8_t rptBits = k.p[k.pattern].t[track].rptBits[i];
+		uint8_t rptBits = k.p[edit_pattern].t[track].rptBits[i];
 		for ( uint8_t j=0; j<5; j++) {
 			uint8_t led = 16*(5-j) + i;
 			monomeLedBuffer[led] = 0;
 			if (rptBits & (1 << j)) {
 				monomeLedBuffer[led] = L0;
 			}
-			if (j < k.p[k.pattern].t[track].rpt[i]) {
+			if (j < k.p[edit_pattern].t[track].rpt[i]) {
 				monomeLedBuffer[led] += grid_varibrightness < 16 ? 4 : 2;
 
-				if ( k.p[k.pattern].t[track].lswap[mRpt] ) {
-					if ( (i < k.p[k.pattern].t[track].lstart[mRpt]) && (i > k.p[k.pattern].t[track].lend[mRpt]) ) {
+				if ( k.p[edit_pattern].t[track].lswap[mRpt] ) {
+					if ( (i < k.p[edit_pattern].t[track].lstart[mRpt]) && (i > k.p[edit_pattern].t[track].lend[mRpt]) ) {
 						monomeLedBuffer[led] -= 2;
 					}
-					else if ( k_mod_mode == modLoop && j < k.p[k.pattern].t[track].rpt[i] ) {
+					else if ( k_mod_mode == modLoop && j < k.p[edit_pattern].t[track].rpt[i] ) {
 						monomeLedBuffer[led] += 1;
 					}
 				}
 				else {
-					if ( (i < k.p[k.pattern].t[track].lstart[mRpt]) || (i > k.p[k.pattern].t[track].lend[mRpt]) ) {
+					if ( (i < k.p[edit_pattern].t[track].lstart[mRpt]) || (i > k.p[edit_pattern].t[track].lend[mRpt]) ) {
 						monomeLedBuffer[led] -= 2;
 					}
-					else if ( k_mod_mode == modLoop && j < k.p[k.pattern].t[track].rpt[i] ) {
+					else if ( k_mod_mode == modLoop && j < k.p[edit_pattern].t[track].rpt[i] ) {
 						monomeLedBuffer[led] += 1;
 					}
 				}
 			}
 		}
-		if ( i == pos[track][mRpt]) {
-			uint8_t y = max(1, activeRpt[track] - repeats[track]);
-			monomeLedBuffer[R6 - y*16 + i] += (rptBits & (1 << y)) ? 4 : 2;
+		if (!meta_lock || edit_pattern == k.pattern) {
+			if ( i == pos[track][mRpt]) {
+				uint8_t y = max(1, activeRpt[track] - repeats[track]);
+				monomeLedBuffer[R6 - y*16 + i] += (rptBits & (1 << y)) ? 4 : 2;
+			}
 		}
 		monomeLedBuffer[i] = 2;
 		monomeLedBuffer[R6+i] = 2;
@@ -3136,10 +3189,10 @@ void refresh_kria_rpt(void) {
 
 void refresh_kria_glide(void) {
 	for(uint8_t i=0;i<16;i++) {
-		for(uint8_t j=0;j<=k.p[k.pattern].t[track].glide[i];j++){
-			monomeLedBuffer[R6-16*j+i] = L1 - (k.p[k.pattern].t[track].glide[i]-j);
-			if(k.p[k.pattern].t[track].lswap[mGlide]) {
-				if((i < k.p[k.pattern].t[track].lstart[mGlide]) && (i > k.p[k.pattern].t[track].lend[mGlide])) {
+		for(uint8_t j=0;j<=k.p[edit_pattern].t[track].glide[i];j++){
+			monomeLedBuffer[R6-16*j+i] = L1 - (k.p[edit_pattern].t[track].glide[i]-j);
+			if(k.p[edit_pattern].t[track].lswap[mGlide]) {
+				if((i < k.p[edit_pattern].t[track].lstart[mGlide]) && (i > k.p[edit_pattern].t[track].lend[mGlide])) {
 					monomeLedBuffer[R6-16*j+i] -= 2;
 
 				}
@@ -3149,15 +3202,17 @@ void refresh_kria_glide(void) {
 			}
 			else
 			{
-				if((i < k.p[k.pattern].t[track].lstart[mGlide]) || (i > k.p[k.pattern].t[track].lend[mGlide])) {
+				if((i < k.p[edit_pattern].t[track].lstart[mGlide]) || (i > k.p[edit_pattern].t[track].lend[mGlide])) {
 					monomeLedBuffer[R6-16*j+i] -= 2;
 				}
 				else if ( k_mod_mode == modLoop ) {
 					monomeLedBuffer[R6-16*j+i] += 1;
 				}
 			}
-			if(i == pos[track][mGlide]) {
-				monomeLedBuffer[R6 - k.p[k.pattern].t[track].glide[i]*16 + i] += 4;
+			if (!meta_lock || edit_pattern == k.pattern) {
+				if(i == pos[track][mGlide]) {
+					monomeLedBuffer[R6 - k.p[k.pattern].t[track].glide[i]*16 + i] += 4;
+				}
 			}
 		}
 	}
@@ -3166,12 +3221,12 @@ void refresh_kria_glide(void) {
 void refresh_kria_scale(void) {
 	for ( uint8_t y=0; y<4; y++ ) {
 		// highlight TT clock enables and trigger steps
-		monomeLedBuffer[0+16*y] = k.p[k.pattern].t[y].tt_clocked ? L1 : L0;
-		monomeLedBuffer[1+16*y] = k.p[k.pattern].t[y].trigger_clocked ? L1 : L0;
+		monomeLedBuffer[0+16*y] = k.p[edit_pattern].t[y].tt_clocked ? L1 : L0;
+		monomeLedBuffer[1+16*y] = k.p[edit_pattern].t[y].trigger_clocked ? L1 : L0;
 
 		// show selected direction
 		for ( uint8_t x=3; x<=7; x++ ) {
-			monomeLedBuffer[x+16*y] = (k.p[k.pattern].t[y].direction == (x - 3)) ? 4 : 2;
+			monomeLedBuffer[x+16*y] = (k.p[edit_pattern].t[y].direction == (x - 3)) ? 4 : 2;
 		}
 	}
 
@@ -3184,11 +3239,11 @@ void refresh_kria_scale(void) {
 		monomeLedBuffer[R6 + i] = 2;
 	}
 	// highlight the selected scale
-	monomeLedBuffer[R5 + (k.p[k.pattern].scale >> 3) * 16 + (k.p[k.pattern].scale & 0x7)] = L1;
+	monomeLedBuffer[R5 + (k.p[edit_pattern].scale >> 3) * 16 + (k.p[edit_pattern].scale & 0x7)] = L1;
 
 	// the intervals of the selected scale
 	for(uint8_t i=0;i<7;i++) {
-		uint8_t scale_pos = scale_data[k.p[k.pattern].scale][i] + 8 + (6-i)*16;
+		uint8_t scale_pos = scale_data[k.p[edit_pattern].scale][i] + 8 + (6-i)*16;
 		monomeLedBuffer[(int)scale_pos + scale_adj[i]] = L0;
 		monomeLedBuffer[scale_pos] = L1;
 	}
@@ -3229,6 +3284,9 @@ void refresh_kria_pattern(void) {
 	}
 	if(cue_pat_next) {
 		monomeLedBuffer[cue_pat_next-1] = L2;
+	}
+	if (meta_lock && kriaMetaLockBlink) {
+		monomeLedBuffer[edit_pattern] += 4;
 	}
 	switch(k_mod_mode) {
 		case modTime:

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -1734,7 +1734,7 @@ void handler_KriaGridKey(s32 data) {
 							change_pattern(x);
 						}
 					}
-					else {
+					else if(!cue) {
 						k.meta_pat[meta_edit] = x;
 					}
 				}
@@ -3004,7 +3004,8 @@ bool refresh_kria_mod(void) {
 		memset(monomeLedBuffer + R5, 3, 16);
 		for(uint8_t i=0;i<16;i++) {
 			if(k.p[edit_pattern].t[track].p[k_mode][i]) {
-				monomeLedBuffer[(5 - k.p[edit_pattern].t[track].p[k_mode][i]) * 16 + i] = i == pos[track][k_mode] ? 10 : 6;
+				monomeLedBuffer[(5 - k.p[edit_pattern].t[track].p[k_mode][i]) * 16 + i] =
+					(edit_pattern == k.pattern && i == pos[track][k_mode]) ? 10 : 6;
 			}
 		}
 		return true;


### PR DESCRIPTION
When meta sequencing is on, hold the pattern key and tap a pattern slot to lock that pattern for editing -- the whole meta sequence continues to run, but the locked pattern's parameters are shown on all parameter pages so you can edit the locked pattern while listening to the whole metasequence. The pattern key flashes as long as the lock is engaged to remind you that the pattern you are editing is not necessarily the same as the one you're hearing. Suggested [here](https://llllllll.co/t/ansible-kria-feature-requests/4846/234).