### PR TITLE
midi: fix tuning behavior & ii leader functionality

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -432,7 +432,7 @@ void grid_keytimer(void) {
 						// reload factory default, don't immediately save it
 						for (uint8_t i = 0; i < 4; i++) {
 							for (uint8_t j = 0; j < 120; j ++) {
-								tuning_table[i][j] = ET[j] << 2;
+								tuning_table[i][j] = ET[j];
 							}
 						}
 						restore_grid_tuning();

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -940,7 +940,8 @@ static void kria_set_note(uint8_t trackNum) {
 		trackNum,
 		(int)cur_scale[noteInScale] +
 		scale_adj[noteInScale] +
-		(int)((oct[trackNum]+octaveBump) * 12));
+		(int)((oct[trackNum]+octaveBump) * 12),
+		0);
 }
 
 void clock_kria_track( uint8_t trackNum ) {
@@ -3636,7 +3637,7 @@ void mp_note_on(uint8_t n) {
 		if(mp_clock_count < 1) {
 			mp_clock_count++;
 			note_now[0] = n;
-			set_cv_note(0, (int)cur_scale[7-n] + scale_adj[7-n]);
+			set_cv_note(0, (int)cur_scale[7-n] + scale_adj[7-n], 0);
 			set_tr(TR1);
 		}
 		break;
@@ -3645,7 +3646,7 @@ void mp_note_on(uint8_t n) {
 			mp_clock_count++;
 			w = get_note_slot(2);
 			note_now[w] = n;
-			set_cv_note(w, (int)cur_scale[7-n] + scale_adj[7-n]);
+			set_cv_note(w, (int)cur_scale[7-n] + scale_adj[7-n], 0);
 			set_tr(TR1 + w);
 		}
 		break;
@@ -3654,7 +3655,7 @@ void mp_note_on(uint8_t n) {
 			mp_clock_count++;
 			w = get_note_slot(4);
 			note_now[w] = n;
-			set_cv_note(w, (int)cur_scale[7-n] + scale_adj[7-n]);
+			set_cv_note(w, (int)cur_scale[7-n] + scale_adj[7-n], 0);
 			set_tr(TR1 + w);
 		}
 		break;
@@ -4470,7 +4471,7 @@ static void es_note_on(s8 x, s8 y, u8 from_pattern, u16 timer, u8 voices) {
         note_index = 0;
     else if (note_index > 119)
         note_index = 119;
-    set_cv_note(note, note_index);
+    set_cv_note(note, note_index, 0);
     dac_update_now();
     set_tr(TR1 + note);
 

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -2790,6 +2790,15 @@ void handler_KriaKey(s32 data) {
 		view_clock = false;
 		break;
 	case 1:
+		if (view_tuning) {
+			view_tuning = false;
+			view_config = false;
+			view_clock = false;
+			restore_grid_tuning();
+			resume_kria();
+			break;
+		}
+
 		grid_refresh = &refresh_clock;
 		// print_dbg("\r\ntime: ");
 		// print_dbg_ulong(time_fine);

--- a/src/ansible_ii_leader.c
+++ b/src/ansible_ii_leader.c
@@ -122,10 +122,10 @@ static void ii_mode_jf(i2c_follower_t* follower, uint8_t track, uint8_t mode) {
 static void ii_octave_jf(i2c_follower_t* follower, uint8_t track, int8_t octave) {
 	int16_t shift;
 	if (octave > 0) {
-		shift = ET[12*octave] << 2;
+		shift = ET[12*octave];
 	}
 	else if (octave < 0) {
-		shift = -(ET[12*(-octave)] << 2);
+		shift = -(ET[12*(-octave)]);
 	}
 	else {
 		shift = 0;
@@ -218,10 +218,10 @@ static void ii_octave_txo(i2c_follower_t* follower, uint8_t track, int8_t octave
 		}
 		case 1: { // gate / cv
 			if (octave > 0) {
-				shift = ET[12*octave] << 2;
+				shift = ET[12*octave];
 			}
 			else if (octave < 0) {
-				shift = -(ET[12*(-octave)] << 2);
+				shift = -ET[12*(-octave)];
 			}
 			else {
 				shift = 0;
@@ -277,7 +277,7 @@ static void ii_cv_txo(i2c_follower_t* follower, uint8_t track, uint16_t dac_valu
 
 	switch (follower->active_mode) {
 		case 0: { // enveloped oscillator
-			dac_value = (int)dac_value + (ET[12*(4+follower->oct)] << 2);
+			dac_value = (int)dac_value + (int)ET[12*(4+follower->oct)];
 			d[0] = 0x40; // TO_OSC
 			d[1] = track;
 			d[2] = dac_value >> 8;

--- a/src/ansible_midi.c
+++ b/src/ansible_midi.c
@@ -14,6 +14,7 @@
 #include "i2c.h"
 #include "gpio.h"
 #include "dac.h"
+#include "music.h"
 
 #include "init_common.h"
 #include "conf_tc_irq.h"
@@ -136,23 +137,6 @@ static void player_note_off(u8 ch, u8 num, u8 vel);
 
 //-----------------------------
 //----- globals
-
-// step = 16384.0 / (10 octave * 12.0 semitones per octave)
-// [int(n * step) for n in xrange(0,128)]
-const u16 SEMI14[128] = {
-	0, 136, 273, 409, 546, 682, 819, 955, 1092, 1228, 1365, 1501, 1638,
-	1774, 1911, 2048, 2184, 2321, 2457, 2594, 2730, 2867, 3003, 3140,
-	3276, 3413, 3549, 3686, 3822, 3959, 4096, 4232, 4369, 4505, 4642,
-	4778, 4915, 5051, 5188, 5324, 5461, 5597, 5734, 5870, 6007, 6144,
-	6280, 6417, 6553, 6690, 6826, 6963, 7099, 7236, 7372, 7509, 7645,
-	7782, 7918, 8055, 8192, 8328, 8465, 8601, 8738, 8874, 9011, 9147,
-	9284, 9420, 9557, 9693, 9830, 9966, 10103, 10240, 10376, 10513, 10649,
-	10786, 10922, 11059, 11195, 11332, 11468, 11605, 11741, 11878, 12014,
-	12151, 12288, 12424, 12561, 12697, 12834, 12970, 13107, 13243, 13380,
-	13516, 13653, 13789, 13926, 14062, 14199, 14336, 14472, 14609, 14745,
-	14882, 15018, 15155, 15291, 15428, 15564, 15701, 15837, 15974, 16110,
-	16247, 16384, 16520, 16657, 16793, 16930, 17066, 17203, 17339
-};
 
 // step = 16384.0 / (10 octave * 12.0 semitones per octave)
 // semi_per_octave = step * 12
@@ -352,8 +336,14 @@ void handler_MidiFrontLong(s32 data) {
 ////////////////////////////////////////////////////////////////////////////////
 ///// common cv utilities
 
+inline static int clamp(int n, int lower, int upper) {
+	if (n < lower) return lower;
+	if (n > upper) return upper;
+	return n;
+}
+
 inline static void midi_pitch(uint8_t n, uint16_t note, int16_t bend) {
-    set_cv_note(n, note, bend + pitch_shift[n]);
+    set_cv_note(n, clamp((int)note - 24, 0, 120), bend);
 }
 
 inline static uint16_t velocity_cv(u8 vel) {
@@ -474,6 +464,16 @@ static void set_voice_slew(voicing_mode v, s16 slew) {
 	}
 }
 
+static int ticks_to_semitones(int16_t shift) {
+	uint16_t mag = abs(shift);
+	for (int i = 0; i < 120; i++) {
+		if (mag > ET[i]) {
+			return shift < 0 ? -i : i;
+		}
+	}
+	return 0;
+}
+
 static void set_voice_tune(voicing_mode v, s16 shift) {
 	u8 i;
 
@@ -481,11 +481,11 @@ static void set_voice_tune(voicing_mode v, s16 shift) {
 	case eVoicePoly:
 	case eVoiceMulti:
 		for (i = 0; i < 4; i++) {
-			pitch_shift[i] = shift;
+			pitch_shift[i] = ticks_to_semitones(shift);
 		}
 		break;
 	case eVoiceMono:
-		pitch_shift[0] = shift;  // pitch
+		pitch_shift[0] = ticks_to_semitones(shift);  // pitch
 		pitch_shift[1] = 0;      // velocity
 		pitch_shift[2] = 0;      // channel pressure
 		pitch_shift[3] = 0;      // mod
@@ -1462,10 +1462,10 @@ void ii_midi_arp(uint8_t *d, uint8_t l) {
 
 			if (v == 0) {
 				for (i = 0; i < 4; i++)
-					pitch_shift[i] = s;
+					pitch_shift[i] = ticks_to_semitones(s);
 			}
 			else {
-				pitch_shift[v-1] = s;
+				pitch_shift[v-1] = ticks_to_semitones(s);
 			}
 			break;
 
@@ -1605,7 +1605,7 @@ void restore_midi_arp(void) {
 		arp_player_set_offset(p, arp_state.p[i].offset);
 		arp_player_set_fill(p, arp_state.p[i].fill);
 
-		pitch_shift[i] = arp_state.p[i].shift;
+		pitch_shift[i] = ticks_to_semitones(arp_state.p[i].shift);
 		dac_set_slew(i, arp_state.p[i].slew);
 	}
 
@@ -1797,7 +1797,7 @@ static void player_note_on(u8 ch, u8 num, u8 vel) {
 	}
 	*/
 
-	midi_pitch(ch, SEMI14[num], 0);
+	midi_pitch(ch, num, 0);
 	multi_tr_set(ch);
 }
 

--- a/src/ansible_midi.c
+++ b/src/ansible_midi.c
@@ -343,7 +343,7 @@ inline static int clamp(int n, int lower, int upper) {
 }
 
 inline static void midi_pitch(uint8_t n, uint16_t note, int16_t bend) {
-    set_cv_note(n, clamp((int)note - 24, 0, 120), bend);
+    set_cv_note(n, clamp((int)note + pitch_shift[n], 0, 120), bend);
 }
 
 inline static uint16_t velocity_cv(u8 vel) {
@@ -467,7 +467,7 @@ static void set_voice_slew(voicing_mode v, s16 slew) {
 static int ticks_to_semitones(int16_t shift) {
 	uint16_t mag = abs(shift);
 	for (int i = 0; i < 120; i++) {
-		if (mag > ET[i]) {
+		if (mag <= ET[i]) {
 			return shift < 0 ? -i : i;
 		}
 	}

--- a/src/ansible_midi.c
+++ b/src/ansible_midi.c
@@ -15,6 +15,7 @@
 #include "gpio.h"
 #include "dac.h"
 #include "music.h"
+#include "util.h"
 
 #include "init_common.h"
 #include "conf_tc_irq.h"
@@ -335,15 +336,8 @@ void handler_MidiFrontLong(s32 data) {
 
 ////////////////////////////////////////////////////////////////////////////////
 ///// common cv utilities
-
-inline static int clamp(int n, int lower, int upper) {
-	if (n < lower) return lower;
-	if (n > upper) return upper;
-	return n;
-}
-
 inline static void midi_pitch(uint8_t n, uint16_t note, int16_t bend) {
-    set_cv_note(n, clamp((int)note + pitch_shift[n], 0, 120), bend);
+    set_cv_note(n, sclip((int)note + pitch_shift[n], 0, 120), bend);
 }
 
 inline static uint16_t velocity_cv(u8 vel) {

--- a/src/main.c
+++ b/src/main.c
@@ -460,7 +460,7 @@ void flash_read(void) {
 void default_tuning(void) {
 	for (uint8_t i = 0; i < 4; i++) {
 		for (uint8_t j = 0; j < 120; j++) {
-			tuning_table[i][j] = ET[j] << 2;
+			tuning_table[i][j] = ET[j];
 		}
 	}
 	flashc_memcpy((void *)f.tuning_table, tuning_table, sizeof(tuning_table), true);
@@ -476,7 +476,7 @@ void fit_tuning(int mode) {
 			for (uint8_t i = 0; i < 4; i++) {
 				uint16_t offset = tuning_table[i][0];
 				for (uint8_t j = 0; j < 120; j++) {
-					tuning_table[i][j] = (ET[j] << 2) + offset;
+					tuning_table[i][j] = ET[j] + offset;
 				}
 			}
 			break;
@@ -555,7 +555,7 @@ void set_cv_note(uint8_t n, uint16_t note, int16_t bend) {
 		bool play_follower = followers[i].active
 				  && followers[i].track_en & (1 << n);
 		if (play_follower) {
-			uint16_t cv_transposed = ((int16_t)ET[note] << 2) + bend;
+			uint16_t cv_transposed = (int16_t)ET[note] + bend;
 			followers[i].cv(&followers[i], n, cv_transposed);
 		}
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -549,13 +549,13 @@ uint8_t get_tr(uint8_t n) {
 	return gpio_get_pin_value(n);
 }
 
-void set_cv_note(uint8_t n, uint16_t note) {
-	dac_set_value(n, tuning_table[n][note]);
+void set_cv_note(uint8_t n, uint16_t note, int16_t bend) {
+	dac_set_value(n, (int16_t)tuning_table[n][note] + bend);
 	for (uint8_t i = 0; i < I2C_FOLLOWER_COUNT; i++) {
 		bool play_follower = followers[i].active
 				  && followers[i].track_en & (1 << n);
 		if (play_follower) {
-			uint16_t cv_transposed = ET[note] << 2;
+			uint16_t cv_transposed = ((int16_t)ET[note] << 2) + bend;
 			followers[i].cv(&followers[i], n, cv_transposed);
 		}
 	}

--- a/src/main.h
+++ b/src/main.h
@@ -95,7 +95,7 @@ void set_mode(ansible_mode_t m);
 void update_leds(uint8_t m);
 void set_tr(uint8_t n);
 void clr_tr(uint8_t n);
-void set_cv_note(uint8_t n, uint16_t cv);
+void set_cv_note(uint8_t n, uint16_t cv, int16_t bend);
 void set_cv_slew(uint8_t n, uint16_t s);
 void reset_outputs(void);
 void toggle_follower(uint8_t n);


### PR DESCRIPTION
Fixes #81 

* Midi mode will now use the user-customized tuning table and use the ii leader functions for sending pitch info.
* Fixed a bug where tuning mode was not properly exited if you pressed KEY1 on the panel.
* Closing the loop on the tuning issues described in https://github.com/monome/libavr32/pull/54 -- in addition to bringing the tuning table in line with Teletype's, the midi note offset is now applied as a semitone offset rather than an offset in DAC ticks, since a constant-valued offset is not the correct adjustment if the user has applied tuning customizations. To avoid breaking existing presets or Teletype behavior, the offsets are still _stored_ in terms of DAC ticks, but they are quantized to the nearest semitone value from the `ET` table to determine the right adjustment in semitones. Huge thanks to @wolfgangschaltung for helping get to the bottom of this and testing numerous builds.