### PR TITLE
use dummy i2c follower address during large flash writes to avoid lockup and preset loss

### DIFF
--- a/src/ansible_arc.c
+++ b/src/ansible_arc.c
@@ -79,7 +79,7 @@ void set_mode_arc(void) {
 		clock = &clock_null;
 		// clock = &clock_levels;
 		// clock_set(f.levels_state.clock_period);
-		if (!leader_mode) init_i2c_slave(II_LV_ADDR);
+		if (!leader_mode) init_i2c_follower(II_LV_ADDR);
 		process_ii = &ii_levels;
 		resume_levels();
 		update_leds(1);
@@ -94,7 +94,7 @@ void set_mode_arc(void) {
 		clock = &clock_cycles;
 		// 24
 		clock_set(DAC_RATE_CV << 3);
-		if (!leader_mode) init_i2c_slave(II_CY_ADDR);
+		if (!leader_mode) init_i2c_follower(II_CY_ADDR);
 		process_ii = &ii_cycles;
 		resume_cycles();
 		update_leds(2);
@@ -108,8 +108,10 @@ void set_mode_arc(void) {
 	// 	app_event_handlers[kEventFrontLong] = &handler_ArcFrontLong;
 	// }
 
+	ii_follower_pause();
 	flashc_memset32((void*)&(f.state.none_mode), ansible_mode, 4, true);
 	flashc_memset32((void*)&(f.state.arc_mode), ansible_mode, 4, true);
+	ii_follower_resume();
 }
 
 
@@ -303,14 +305,18 @@ void handler_ArcPresetKey(s32 data) {
 		// print_dbg_ulong(arc_preset);
 		switch(ansible_mode) {
 		case mArcLevels:
+			ii_follower_pause();
 			flashc_memcpy((void *)&f.levels_state.l[arc_preset], &l, sizeof(l), true);
 			flashc_memset8((void*)&(f.levels_state.preset), arc_preset, 1, true);
+			ii_follower_resume();
 			arc_leave_preset();
 			resume_levels();
 			break;
 		case mArcCycles:
+			ii_follower_pause();
 			flashc_memcpy((void *)&f.cycles_state.c[arc_preset], &c, sizeof(c), true);
 			flashc_memset8((void*)&(f.cycles_state.preset), arc_preset, 1, true);
+			ii_follower_resume();
 			arc_leave_preset();
 			resume_cycles();
 			break;

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -146,7 +146,7 @@ void set_mode_grid() {
 		app_event_handlers[kEventMonomeRefresh] = &handler_KriaRefresh;
 		clock = &clock_kria;
 		clock_set(clock_period);
-		if (!leader_mode) init_i2c_slave(II_KR_ADDR);
+		if (!leader_mode) init_i2c_follower(II_KR_ADDR);
 		process_ii = &ii_kria;
 		resume_kria();
 		update_leds(1);
@@ -160,7 +160,7 @@ void set_mode_grid() {
 		app_event_handlers[kEventMonomeRefresh] = &handler_MPRefresh;
 		clock = &clock_mp;
 		clock_set(clock_period);
-		if (!leader_mode) init_i2c_slave(II_MP_ADDR);
+		if (!leader_mode) init_i2c_follower(II_MP_ADDR);
 		process_ii = &ii_mp;
 		resume_mp();
 		update_leds(2);
@@ -174,7 +174,7 @@ void set_mode_grid() {
 		app_event_handlers[kEventMonomeRefresh] = &handler_ESRefresh;
 		clock = &clock_null;
 		clock_set(clock_period);
-		if (!leader_mode) init_i2c_slave(ES);
+		if (!leader_mode) init_i2c_follower(ES);
 		process_ii = &ii_es;
 		resume_es();
 		update_leds(3);
@@ -188,8 +188,10 @@ void set_mode_grid() {
 	// 	app_event_handlers[kEventFrontLong] = &handler_GridFrontLong;
 	// }
 
+	ii_follower_pause();
 	flashc_memset32((void*)&(f.state.none_mode), ansible_mode, 4, true);
 	flashc_memset32((void*)&(f.state.grid_mode), ansible_mode, 4, true);
+	ii_follower_resume();
 }
 
 static void preset_mode_exit(void) {
@@ -377,6 +379,8 @@ void grid_keytimer(void) {
 
 					// WRITE PRESET
 
+					ii_follower_pause();
+
 					switch (ansible_mode) {
 					case mGridMP:
 						flashc_memset8((void*)&(f.mp_state.preset), preset, 1, true);
@@ -419,6 +423,8 @@ void grid_keytimer(void) {
 					flashc_memset32((void*)&(f.kria_state.clock_period), clock_period, 4, true);
 					flashc_memset32((void*)&(f.kria_state.sync_mode), kria_sync_mode, sizeof(kria_sync_mode), true);
 
+					ii_follower_resume();
+
 					monomeFrameDirty++;
 				}
 			}
@@ -440,18 +446,24 @@ void grid_keytimer(void) {
 					if (x == 13) {
 						// apply fixed offset and save
 						fit_tuning(0);
+						ii_follower_pause();
 						flashc_memcpy((void*)f.tuning_table, tuning_table, sizeof(tuning_table), true);
+						ii_follower_resume();
 						restore_grid_tuning();
 					}
 					if (x == 14) {
 						// interpolate octaves and save
 						fit_tuning(1);
+						ii_follower_pause();
 						flashc_memcpy((void*)f.tuning_table, tuning_table, sizeof(tuning_table), true);
+						ii_follower_resume();
 						restore_grid_tuning();
 					}
 					if (x == 15) {
 						// save all tuning entries as-is
+						ii_follower_pause();
 						flashc_memcpy((void *)f.tuning_table, tuning_table, sizeof(tuning_table), true);
+						ii_follower_resume();
 						restore_grid_tuning();
 					}
 				}

--- a/src/ansible_ii_leader.c
+++ b/src/ansible_ii_leader.c
@@ -6,7 +6,7 @@
 #include "music.h"
 
 static void ii_init_jf(i2c_follower_t* follower, uint8_t track, uint8_t state) {
-	uint8_t d[3] = { 0 };
+	uint8_t d[4] = { 0 };
 
 	if (!state)
 	{
@@ -15,18 +15,18 @@ static void ii_init_jf(i2c_follower_t* follower, uint8_t track, uint8_t state) {
 		d[1] = 0;
 		d[2] = 16384 >> 8;
 		d[3] = 16834 & 0xFF;
-		i2c_master_tx(follower->addr, d, 3);
+		i2c_leader_tx(follower->addr, d, 3);
 
 		// clear all triggers to avoid hanging notes in SUSTAIN
 		d[0] = JF_TR;
 		d[1] = 0;
 		d[2] = 0;
-		i2c_master_tx(follower->addr, d, 3);
+		i2c_leader_tx(follower->addr, d, 3);
 	}
 
 	d[0] = JF_MODE;
 	d[1] = state;
-	i2c_master_tx(follower->addr, d, 2);
+	i2c_leader_tx(follower->addr, d, 2);
 }
 
 static void ii_tr_jf(i2c_follower_t* follower, uint8_t track, uint8_t state) {
@@ -87,7 +87,7 @@ static void ii_tr_jf(i2c_follower_t* follower, uint8_t track, uint8_t state) {
 		}
 	}
 	if (l > 0) {
-		i2c_master_tx(follower->addr, d, l);
+		i2c_leader_tx(follower->addr, d, l);
 	}
 }
 
@@ -98,7 +98,7 @@ static void ii_mute_jf(i2c_follower_t* follower, uint8_t track, uint8_t mode) {
 	d[0] = JF_TR;
 	d[1] = 0;
 	d[2] = 0;
-	i2c_master_tx(follower->addr, d, 3);
+	i2c_leader_tx(follower->addr, d, 3);
 }
 
 static void ii_mode_jf(i2c_follower_t* follower, uint8_t track, uint8_t mode) {
@@ -109,20 +109,20 @@ static void ii_mode_jf(i2c_follower_t* follower, uint8_t track, uint8_t mode) {
 	if (mode == 2) {
 		d[0] = JF_MODE;
 		d[1] = 0;
-		i2c_master_tx(follower->addr, d, 2);
+		i2c_leader_tx(follower->addr, d, 2);
 
 		// clear all triggers to avoid hanging notes in SUSTAIN
 		d[0] = JF_TR;
 		d[1] = 0;
 		d[2] = 0;
 		d[3] = 0;
-		i2c_master_tx(follower->addr, d, 3);
+		i2c_leader_tx(follower->addr, d, 3);
 	}
 	else
 	{
 		d[0] = JF_MODE;
 		d[1] = 1;
-		i2c_master_tx(follower->addr, d, 2);
+		i2c_leader_tx(follower->addr, d, 2);
 	}
 }
 
@@ -139,7 +139,7 @@ static void ii_octave_jf(i2c_follower_t* follower, uint8_t track, int8_t octave)
 	}
 
 	uint8_t d[] = { JF_SHIFT, shift >> 8, shift & 0xFF };
-	i2c_master_tx(follower->addr, d, 3);
+	i2c_leader_tx(follower->addr, d, 3);
 }
 
 static void ii_init_txo(i2c_follower_t* follower, uint8_t track, uint8_t state) {
@@ -150,19 +150,19 @@ static void ii_init_txo(i2c_follower_t* follower, uint8_t track, uint8_t state) 
 		d[1] = track;
 		d[2] = 0;
 		d[3] = 0;
-		i2c_master_tx(follower->addr, d, 4);
+		i2c_leader_tx(follower->addr, d, 4);
 
 		d[0] = 0x40; // TO_OSC
 		d[1] = track;
 		d[2] = 0;
 		d[3] = 0;
-		i2c_master_tx(follower->addr, d, 4);
+		i2c_leader_tx(follower->addr, d, 4);
 
 		d[0] = 0x10; // TO_CV
 		d[1] = track;
 		d[2] = 0;
 		d[3] = 0;
-		i2c_master_tx(follower->addr, d, 4);
+		i2c_leader_tx(follower->addr, d, 4);
 	}
 }
 
@@ -178,19 +178,19 @@ static void ii_mode_txo(i2c_follower_t* follower, uint8_t track, uint8_t mode) {
 			d[1] = track;
 			d[2] = 0;
 			d[3] = 1;
-			i2c_master_tx(follower->addr, d, 4);
+			i2c_leader_tx(follower->addr, d, 4);
 
 			d[0] = 0x15; // TO_CV_OFF
 			d[1] = track;
 			d[2] = 0;
 			d[3] = 0;
-			i2c_master_tx(follower->addr, d, 4);
+			i2c_leader_tx(follower->addr, d, 4);
 
 			d[0] = 0x10; // TO_CV
 			d[1] = track;
 			d[2] = 8192 >> 8;
 			d[3] = 8192 & 0xFF;
-			i2c_master_tx(follower->addr, d, 4);
+			i2c_leader_tx(follower->addr, d, 4);
 			break;
 		}
 		case 1: { // gate/cv
@@ -198,19 +198,19 @@ static void ii_mode_txo(i2c_follower_t* follower, uint8_t track, uint8_t mode) {
 			d[1] = track;
 			d[2] = 0;
 			d[3] = 0;
-			i2c_master_tx(follower->addr, d, 4);
+			i2c_leader_tx(follower->addr, d, 4);
 
 			d[0] = 0x40; // TO_OSC
 			d[1] = track;
 			d[2] = 0;
 			d[3] = 0;
-			i2c_master_tx(follower->addr, d, 4);
+			i2c_leader_tx(follower->addr, d, 4);
 
 			d[0] = 0x10; // TO_CV
 			d[1] = track;
 			d[2] = 0;
 			d[3] = 0;
-			i2c_master_tx(follower->addr, d, 4);
+			i2c_leader_tx(follower->addr, d, 4);
 			break;
 		}
 		default: return;
@@ -241,7 +241,7 @@ static void ii_octave_txo(i2c_follower_t* follower, uint8_t track, int8_t octave
 			};
 			for (uint8_t i = 0; i < 4; i++) {
 				d[1] = i;
-				i2c_master_tx(follower->addr, d, 4);
+				i2c_leader_tx(follower->addr, d, 4);
 			}
 			break;
 		}
@@ -258,7 +258,7 @@ static void ii_tr_txo(i2c_follower_t* follower, uint8_t track, uint8_t state) {
 			d[1] = track;
 			d[2] = 0;
 			d[3] = state;
-			i2c_master_tx(follower->addr, d, 4);
+			i2c_leader_tx(follower->addr, d, 4);
 			break;
 		}
 		case 1: { // gate/cv
@@ -266,7 +266,7 @@ static void ii_tr_txo(i2c_follower_t* follower, uint8_t track, uint8_t state) {
 			d[1] = track;
 			d[2] = 0;
 			d[3] = state;
-			i2c_master_tx(follower->addr, d, 4);
+			i2c_leader_tx(follower->addr, d, 4);
 			break;
 		}
 		default: return;
@@ -289,7 +289,7 @@ static void ii_cv_txo(i2c_follower_t* follower, uint8_t track, uint16_t dac_valu
 			d[1] = track;
 			d[2] = dac_value >> 8;
 			d[3] = dac_value & 0xFF;
-			i2c_master_tx(follower->addr, d, 4);
+			i2c_leader_tx(follower->addr, d, 4);
 			break;
 		}
 		case 1: { // gate/cv
@@ -297,7 +297,7 @@ static void ii_cv_txo(i2c_follower_t* follower, uint8_t track, uint16_t dac_valu
 			d[1] = track;
 			d[2] = dac_value >> 8;
 			d[3] = dac_value & 0xFF;
-			i2c_master_tx(follower->addr, d, 4);
+			i2c_leader_tx(follower->addr, d, 4);
 			break;
 		}
 		default: return;
@@ -313,7 +313,7 @@ static void ii_slew_txo(i2c_follower_t* follower, uint8_t track, uint16_t slew) 
 			d[1] = track;
 			d[2] = slew >> 8;
 			d[3] = slew & 0xFF;
-			i2c_master_tx(follower->addr, d, 4);
+			i2c_leader_tx(follower->addr, d, 4);
 			break;
 		}
 		case 1: { // gate/cv
@@ -321,7 +321,7 @@ static void ii_slew_txo(i2c_follower_t* follower, uint8_t track, uint16_t slew) 
 			d[1] = track;
 			d[2] = slew >> 8;
 			d[3] = slew & 0xFF;
-			i2c_master_tx(follower->addr, d, 4);
+			i2c_leader_tx(follower->addr, d, 4);
 			break;
 		}
 		default: return;

--- a/src/ansible_midi.c
+++ b/src/ansible_midi.c
@@ -227,7 +227,7 @@ void set_mode_midi(void) {
 		app_event_handlers[kEventTrNormal] = &handler_StandardTrNormal;
 		app_event_handlers[kEventMidiPacket] = &handler_StandardMidiPacket;
 		restore_midi_standard();
-		if (!leader_mode) init_i2c_slave(II_MID_ADDR);
+		if (!leader_mode) init_i2c_follower(II_MID_ADDR);
 		process_ii = &ii_midi_standard;
 		update_leds(1);
 		break;
@@ -241,7 +241,7 @@ void set_mode_midi(void) {
 		restore_midi_arp();
 		clock = &clock_midi_arp;
 		clock_set(arp_state.clock_period);
-		if (!leader_mode) init_i2c_slave(II_ARP_ADDR);
+		if (!leader_mode) init_i2c_follower(II_ARP_ADDR);
 		process_ii = &ii_midi_arp;
 		update_leds(2);
 		break;
@@ -525,6 +525,8 @@ void default_midi_standard(void) {
 }
 
 void write_midi_standard(void) {
+	ii_follower_pause();
+
 	flashc_memset32((void*)&(f.midi_standard_state.clock_period),
 									standard_state.clock_period, 4, true);
 	flashc_memset8((void*)&(f.midi_standard_state.voicing),
@@ -537,6 +539,7 @@ void write_midi_standard(void) {
 	flashc_memset16((void*)&(f.midi_standard_state.slew),
 									standard_state.slew, 2, true);
 
+	ii_follower_resume();
 }
 
 void clock_midi_standard(uint8_t phase) {
@@ -1169,6 +1172,8 @@ void default_midi_arp() {
 void write_midi_arp(void) {
 	arp_player_t *p;
 
+	ii_follower_pause();
+
 	flashc_memset32((void*)&(f.midi_arp_state.clock_period),
 									arp_state.clock_period, 4, true);
 	flashc_memset8((void*)&(f.midi_arp_state.style),
@@ -1197,6 +1202,8 @@ void write_midi_arp(void) {
 		flashc_memset16((void*)&(f.midi_arp_state.p[i].shift),
 										dac_get_off(i), 2, true);
 	}
+
+	ii_follower_resume();
 }
 
 static void arp_next_style(void) {

--- a/src/ansible_tt.c
+++ b/src/ansible_tt.c
@@ -22,7 +22,7 @@ void set_mode_tt(void) {
 	app_event_handlers[kEventTrNormal] = &handler_TTTrNormal;
 	clock = &clock_tt;
 	clock_set(f.tt_state.clock_period);
-	if (!leader_mode) init_i2c_slave(f.state.i2c_addr);
+	if (!leader_mode) init_i2c_follower(f.state.i2c_addr);
 	process_ii = &ii_tt;
 	update_leds(0);
 

--- a/src/ansible_usb_disk.c
+++ b/src/ansible_usb_disk.c
@@ -393,6 +393,7 @@ static bool usb_disk_load_flash(FS_STRING fname) {
 		print_dbg("\r\n!! could not open JSON file for read");
 		return false;
 	}
+	ii_follower_pause();
 	json_read_result_t result = json_read(
 		gets_chunks,
 		copy_chunks,
@@ -400,6 +401,7 @@ static bool usb_disk_load_flash(FS_STRING fname) {
 		ansible_usb_disk_textbuf, ANSIBLE_USBDISK_TXTBUF_LEN,
 		ansible_usb_disk_tokbuf, ANSIBLE_USBDISK_TOKBUF_LEN);
 	file_close();
+	ii_follower_resume();
 
 	switch (result) {
 	case JSON_READ_OK:

--- a/src/main.c
+++ b/src/main.c
@@ -328,7 +328,7 @@ static void handler_FrontLong(s32 data) {
 	print_dbg("\r\n+ i2c address: ");
 	print_dbg_hex(f.state.i2c_addr);
 	// TEST
-	if (!leader_mode) init_i2c_slave(f.state.i2c_addr);
+	if (!leader_mode) init_i2c_follower(f.state.i2c_addr);
 }
 
 static void handler_SaveFlash(s32 data) {
@@ -611,7 +611,7 @@ void toggle_follower(uint8_t n) {
 		}
 		print_dbg("\r\n> enter i2c leader mode");
 		leader_mode = true;
-		init_i2c_master();
+		init_i2c_leader();
 		follower_on(n);
 	}
 	else {
@@ -623,30 +623,44 @@ void toggle_follower(uint8_t n) {
 		}
 		print_dbg("\r\n> exit i2c leader mode");
 		leader_mode = false;
+		ii_follower_resume();
+	}
+}
+
+void ii_follower_pause(void) {
+	if (!leader_mode) {
+		// 0x03 is a reserved address 'for future use' in the i2c spec
+		// used to effectively stop listening for i2c
+		init_i2c_follower(0x03);
+	}
+}
+
+void ii_follower_resume(void) {
+	if (!leader_mode) {
 		switch (ansible_mode) {
 		case mArcLevels:
-			init_i2c_slave(II_LV_ADDR);
+			init_i2c_follower(II_LV_ADDR);
 			break;
 		case mArcCycles:
-			init_i2c_slave(II_CY_ADDR);
+			init_i2c_follower(II_CY_ADDR);
 			break;
 		case mGridKria:
-			init_i2c_slave(II_KR_ADDR);
+			init_i2c_follower(II_KR_ADDR);
 			break;
 		case mGridMP:
-			init_i2c_slave(II_MP_ADDR);
+			init_i2c_follower(II_MP_ADDR);
 			break;
 		case mGridES:
-			init_i2c_slave(ES);
+			init_i2c_follower(ES);
 			break;
 		case mMidiStandard:
-			init_i2c_slave(II_MID_ADDR);
+			init_i2c_follower(II_MID_ADDR);
 			break;
 		case mMidiArp:
-			init_i2c_slave(II_ARP_ADDR);
+			init_i2c_follower(II_ARP_ADDR);
 			break;
 		case mTT:
-			init_i2c_slave(f.state.i2c_addr);
+			init_i2c_follower(f.state.i2c_addr);
 			break;
 	        default:
 			break;
@@ -684,13 +698,13 @@ void load_flash_state(void) {
 		if (followers[i].active) {
 			if (!leader_mode) {
 				leader_mode = true;
-				init_i2c_master();
+				init_i2c_leader();
 			}
 			follower_on(i);
 		}
 	}
 	if (!leader_mode) {
-		init_i2c_slave(f.state.i2c_addr);
+		init_i2c_follower(f.state.i2c_addr);
 	}
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -90,6 +90,8 @@ void fit_tuning(int mode);
 extern void handler_None(s32 data);
 extern void clock_null(u8 phase);
 extern void ii_null(uint8_t *d, uint8_t l);
+extern void ii_follower_pause(void);
+extern void ii_follower_resume(void);
 
 void set_mode(ansible_mode_t m);
 void update_leds(uint8_t m);


### PR DESCRIPTION
Fixes #86 as best as I can tell, see discussion there.

* Disables I2C while saving presets by changing the listening address to 0x03 -- this is a "reserved for future use" address for the I2C protocol so nothing should be using it.
* Change I2C terminology to match https://github.com/monome/libavr32/pull/55