### PR TITLE
kria: option for reset input to reset the metapattern playhead

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -69,6 +69,7 @@ uint8_t cue_div;
 uint8_t cue_steps;
 
 uint8_t meta;
+bool meta_reset_all;
 
 uint8_t scale_data[16][8];
 
@@ -395,6 +396,7 @@ void grid_keytimer(void) {
 						flashc_memset8((void*)&(f.kria_state.cue_div), cue_div, 1, true);
 						flashc_memset8((void*)&(f.kria_state.cue_steps), cue_steps, 1, true);
 						flashc_memset8((void*)&(f.kria_state.meta), meta, 1, true);
+						flashc_memset8((void*)&(f.kria_state.meta_reset_all), meta_reset_all, 1, true);
 						flashc_memcpy((void *)&f.kria_state.k[preset], &k, sizeof(k), true);
 
 						flashc_memcpy((void *)&f.scale, &scale_data, sizeof(scale_data), true);
@@ -542,6 +544,7 @@ uint8_t div_sync;
 u8 pos[4][KRIA_NUM_PARAMS];
 u8 pos_mul[4][KRIA_NUM_PARAMS];
 bool pos_reset;
+bool meta_reset;
 u8 tr[4];
 u8 note[4];
 u8 oct[4];
@@ -604,6 +607,7 @@ void default_kria() {
 	flashc_memset8((void*)&(f.kria_state.cue_div), 0, 1, true);
 	flashc_memset8((void*)&(f.kria_state.cue_steps), 3, 1, true);
 	flashc_memset8((void*)&(f.kria_state.meta), 0, 1, true);
+	flashc_memset8((void*)&(f.kria_state.meta_reset_all), false, 1, true);
 
 	for(i1=0;i1<8;i1++)
 		k.glyph[i1] = 0;
@@ -661,6 +665,7 @@ void init_kria() {
 	div_sync = f.kria_state.div_sync;
 	cue_div = f.kria_state.cue_div;
 	cue_steps = f.kria_state.cue_steps;
+	meta_reset_all = f.kria_state.meta_reset_all;
 
 	preset = f.kria_state.preset;
 
@@ -887,6 +892,14 @@ void clock_kria(uint8_t phase) {
 					cue_pat_next = 0;
 				}
 			}
+		}
+
+		if (meta && meta_reset) {
+			meta_pos = k.meta_start;
+			change_pattern(k.meta_pat[meta_pos]);
+			meta_next = 0;
+			meta_count = 0;
+			meta_reset = false;
 		}
 
 		if(pos_reset) {
@@ -1885,6 +1898,9 @@ void handler_KriaGridKey(s32 data) {
 				grid_refresh = &refresh_grid_tuning;
 				restore_grid_tuning();
 			}
+			else if (y == 7 && x == 15) {
+				meta_reset_all = !meta_reset_all;
+			}
 			monomeFrameDirty++;
 		}
 	}
@@ -2882,6 +2898,7 @@ void handler_KriaTr(s32 data) {
 		break;
 	case 3:
 		pos_reset = true;
+		if (meta && meta_reset_all) meta_reset = true;
 		break;
 	default:
 		break;
@@ -3337,6 +3354,7 @@ void refresh_kria_config(void) {
 	monomeLedBuffer[R5 + 13] = i;
 
 	monomeLedBuffer[R7 + 14] = L0;
+	monomeLedBuffer[R7 + 15] = meta_reset_all ? L1 : L0;
 }
 
 

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -1913,6 +1913,7 @@ void handler_KriaGridKey(s32 data) {
 			}
 			else if (y == 7 && x == 15) {
 				meta_reset_all = !meta_reset_all;
+				flashc_memset8((void*)&(f.kria_state.meta_reset_all), meta_reset_all, 1, true);
 			}
 			monomeFrameDirty++;
 		}

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -95,6 +95,7 @@ typedef struct {
 	uint8_t cue_div;
 	uint8_t cue_steps;
 	uint8_t meta;
+	bool meta_reset_all;
 	kria_data_t k[GRID_PRESETS];
 } kria_state_t;
 

--- a/src/ansible_preset_docdef.c
+++ b/src/ansible_preset_docdef.c
@@ -243,7 +243,7 @@ json_docdef_t ansible_app_docdefs[] = {
 		.write = json_write_object,
 		.state = &ansible_app_object_state[0],
 		.params = &((json_read_object_params_t) {
-			.docdef_ct = 11,
+			.docdef_ct = 12,
 			.docdefs = ((json_docdef_t[]) {
 				{
 					.name = "clock_period",
@@ -333,6 +333,15 @@ json_docdef_t ansible_app_docdefs[] = {
 					.params = &((json_read_scalar_params_t) {
 						.dst_size = sizeof_field(nvram_data_t, kria_state.meta),
 						.dst_offset = offsetof(nvram_data_t, kria_state.meta),
+					}),
+				},
+				{
+					.name = "meta_reset_all",
+					.read = json_read_scalar,
+					.write = json_write_bool,
+					.params = &((json_read_scalar_params_t) {
+						.dst_size = sizeof_field(nvram_data_t, kria_state.meta_reset_all),
+						.dst_offset = offsetof(nvram_data_t, kria_state.meta_reset_all),
 					}),
 				},
 				{


### PR DESCRIPTION
In Kria, a trigger to the reset input currently resets the playhead within the current pattern, but does not reset the metapattern playhead to the first pattern in the metapattern sequence. This patch adds a toggle to enable resetting the metapattern playhead as well, activated by holding key 2 (CONFIG) and pressing the bottom-right (pattern page select) key.

Common user request, e.g. https://llllllll.co/t/ansible-help-and-issues/21188/72, that I apparently put in the beta a while ago but forgot about.