### PR TITLE
drop unneeded firmware name in docdef

### DIFF
--- a/src/ansible_preset_docdef.c
+++ b/src/ansible_preset_docdef.c
@@ -45,14 +45,6 @@ DECLARE_STATIC_ALLOC(levels_data_t, l)
 
 json_docdef_t ansible_meta_docdefs[] = {
 	{
-		.name = "firmware",
-		.read = json_match_string,
-		.write = json_write_constant_string,
-		.params = &((json_match_string_params_t) {
-			.to_match = ANSIBLE_FIRMWARE_NAME,
-		}),
-	},
-	{
 		.name = "version",
 		.read = json_match_string,
 		.write = json_write_constant_string,


### PR DESCRIPTION
For reasons I haven't been able to tease apart yet, loading a preset file from disk is failing unless I remove this field. This isn't used for anything, it's just a marker at the start of the file that says it is an Ansible preset, which the filename already tells you.