### PR TITLE
support W/syn and crow as ii followers

### DIFF
--- a/src/ansible_ii_leader.h
+++ b/src/ansible_ii_leader.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define I2C_FOLLOWER_COUNT 4
+#define I2C_FOLLOWER_COUNT 6
 
 struct i2c_follower_t;
 
@@ -8,23 +8,28 @@ typedef void(*ii_u8_cb)(struct i2c_follower_t* follower, uint8_t track, uint8_t 
 typedef void(*ii_s8_cb)(struct i2c_follower_t* follower, uint8_t track, int8_t param);
 typedef void(*ii_u16_cb)(struct i2c_follower_t* follower, uint8_t track, uint16_t param);
 
-typedef struct i2c_follower_t {
-  uint8_t addr;
-	bool active;
-	uint8_t track_en;
-	int8_t oct;
 
+typedef struct i2c_ops_t {
 	ii_u8_cb init;
 	ii_u8_cb mode;
 	ii_u8_cb tr;
-        ii_u8_cb mute;
+	ii_u8_cb mute;
 
 	ii_u16_cb cv;
 	ii_u16_cb slew;
 	ii_s8_cb octave;
 
 	uint8_t mode_ct;
+} i2c_ops_t;
+
+typedef struct i2c_follower_t {
+	uint8_t addr;
+	bool active;
+	uint8_t track_en;
+	int8_t oct;
 	uint8_t active_mode;
+
+	i2c_ops_t* ops;
 } i2c_follower_t;
 
 extern i2c_follower_t followers[I2C_FOLLOWER_COUNT];

--- a/src/main.c
+++ b/src/main.c
@@ -528,7 +528,7 @@ void set_tr(uint8_t n) {
 		bool play_follower = followers[i].active
 				  && followers[i].track_en & (1 << tr);
 		if (play_follower) {
-			followers[i].tr(&followers[i], tr, 1);
+			followers[i].ops->tr(&followers[i], tr, 1);
 		}
 	}
 }
@@ -540,7 +540,7 @@ void clr_tr(uint8_t n) {
 		bool play_follower = followers[i].active
 				  && followers[i].track_en & (1 << tr);
 		if (play_follower) {
-			followers[i].tr(&followers[i], tr, 0);
+			followers[i].ops->tr(&followers[i], tr, 0);
 		}
 	}
 }
@@ -556,7 +556,7 @@ void set_cv_note(uint8_t n, uint16_t note, int16_t bend) {
 				  && followers[i].track_en & (1 << n);
 		if (play_follower) {
 			uint16_t cv_transposed = (int16_t)ET[note] + bend;
-			followers[i].cv(&followers[i], n, cv_transposed);
+			followers[i].ops->cv(&followers[i], n, cv_transposed);
 		}
 	}
 }
@@ -567,7 +567,7 @@ void set_cv_slew(uint8_t n, uint16_t s) {
 		bool play_follower = followers[i].active
 				  && followers[i].track_en & (1 << n);
 		if (play_follower) {
-			followers[i].slew(&followers[i], n, s);
+			followers[i].ops->slew(&followers[i], n, s);
 		}
 	}
 }
@@ -580,7 +580,7 @@ void reset_outputs(void) {
 			bool play_follower = followers[i].active
 			  && followers[i].track_en & (1 << n);
 			if (play_follower) {
-				followers[i].mute(&followers[n], 0, 0);
+				followers[i].ops->mute(&followers[n], 0, 0);
 			}
 		}
 	}
@@ -588,15 +588,15 @@ void reset_outputs(void) {
 
 static void follower_on(uint8_t n) {
 	for (uint8_t i = 0; i < 4; i++) {
-		followers[n].init(&followers[n], i, 1);
-		followers[n].mode(&followers[n], i, followers[n].active_mode);
-		followers[n].octave(&followers[n], 0, followers[n].oct);
+		followers[n].ops->init(&followers[n], i, 1);
+		followers[n].ops->mode(&followers[n], i, followers[n].active_mode);
+		followers[n].ops->octave(&followers[n], 0, followers[n].oct);
 	}
 }
 
 static void follower_off(uint8_t n) {
 	for (uint8_t i = 0; i < 4; i++) {
-		followers[n].init(&followers[n], i, 0);
+		followers[n].ops->init(&followers[n], i, 0);
 	}
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -74,13 +74,21 @@ typedef const struct {
 	uint16_t tuning_table[4][120];
 } nvram_data_t;
 
+typedef struct {
+	bool tr;
+	uint16_t semitones;
+	int16_t bend;
+	uint16_t slew;
+	uint16_t dac_target;
+} ansible_output_t;
+
 extern nvram_data_t f;
 extern ansible_mode_t ansible_mode;
 extern i2c_follower_t followers[I2C_FOLLOWER_COUNT];
 
 extern softTimer_t auxTimer[4];
 extern uint16_t tuning_table[4][120];
-
+extern ansible_output_t outputs[4];
 
 void (*clock)(u8 phase);
 void init_tuning(void);


### PR DESCRIPTION
- add W/syn as an additional ii follower. requires W/ [beta firmware w2b07](https://llllllll.co/t/mannequins-w-2-beta-testing/34091).
- add crow as an additional ii follower, sending pitch and velocity values to crow when ansible apps fire a trigger. requires crow firmware v2.1.2.
- split ii follower control functions out to a separate `ops` struct, saving on the amount of flash consumed for ii follower configuration
- fix a design problem where applying custom tuning adjustments to ansible's CV outputs would also affect pitches sent to ii followers, causing ii followers to play out of tune (huge thanks @scanner-darkly for testing / fixing this change for Disting EX)
- fix a [bug](https://github.com/monome/libavr32/pull/63) with JSON scalars that are split across two reads from the USB disk, causing some USB disk presets to fail to load