### PR TITLE
summarize changes since last release in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## v3.1.0
+- **FIX**: tuning customization behavior in midi modes
+- **FIX**: send original rather than customized pitch table values to ii followers
+- **FIX**: bugs preventing saving / loading some presets to USB
+- **FIX**: disable i2c during preset writes to prevent possible loss of data
+- **FIX**: improve delay when connecting grid and arc
+- **FIX**: reset JF velocity when exiting leader mode
+- **NEW**: freeze one pattern for editing while meta sequence continues to run
+- **NEW**: optionally reset the entire meta pattern on a reset trigger
+- **NEW**: optionally always tie notes when duration is maxed
+- **NEW**: Disting EX as ii follower
+- **NEW**: W/syn as ii follower
+- **NEW**: crow as ii follower
+- **NEW**: supports new `ES.CV` teletype op
+
+
 ## v3.0.0
 
 - **NEW**: i2c leader mode for controlling Just Friends, TELEXo, or ER-301 from ansible


### PR DESCRIPTION
I added this as the last thing before the previous release and immediately forgot I had done so for the past year's worth of work.

I believe this Ansible revision is now ready for release (minus docs, gulp) but a beta of the current version was only posted today.