### PR TITLE
fix metapattern out of bounds and levels ii

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -2116,7 +2116,10 @@ void handler_KriaGridKey(s32 data) {
 				case 11:
 					k_mod_mode = modTime; break;
 				case 12:
-					k_mod_mode = modProb; break;
+					if (k_mode < KRIA_NUM_PARAMS) {
+						k_mod_mode = modProb;
+					}
+					break;
 				case 14:
 					k_mode = mScale; break;
 				case 15:
@@ -2983,7 +2986,9 @@ void refresh_kria(void) {
 	memset(monomeLedBuffer + R7 + 5, L0, 4);
 	monomeLedBuffer[R7 + 10] = L0;
 	monomeLedBuffer[R7 + 11] = L0;
-	monomeLedBuffer[R7 + 12] = L0;
+	if (k_mode < KRIA_NUM_PARAMS) {
+		monomeLedBuffer[R7 + 12] = L0;
+	}
 	monomeLedBuffer[R7 + 14] = L0;
 	monomeLedBuffer[R7 + 15] = (meta && meta_lock && kriaMetaLockBlink) ? L1 : L0;
 
@@ -3068,15 +3073,22 @@ bool refresh_kria_mod(void) {
 	case modTime:
 		monomeLedBuffer[R7 + 11] = L1;
 		memset(monomeLedBuffer + R1, 3, 16);
-		monomeLedBuffer[R1 + k.p[edit_pattern].t[track].tmul[k_mode] - 1] = L1;
+		if (k_mode < KRIA_NUM_PARAMS) {
+			monomeLedBuffer[R1 + k.p[edit_pattern].t[track].tmul[k_mode] - 1] = L1;
+		}
+		else if (k_mode == mPattern) {
+			monomeLedBuffer[R1 + cue_div] = L1;
+		}
 		return true;
 	case modProb:
 		monomeLedBuffer[R7 + 12] = L1;
 		memset(monomeLedBuffer + R5, 3, 16);
-		for(uint8_t i=0;i<16;i++) {
-			if(k.p[edit_pattern].t[track].p[k_mode][i]) {
-				monomeLedBuffer[(5 - k.p[edit_pattern].t[track].p[k_mode][i]) * 16 + i] =
-					(edit_pattern == k.pattern && i == pos[track][k_mode]) ? 10 : 6;
+		if (k_mode < KRIA_NUM_PARAMS) {
+			for(uint8_t i=0;i<16;i++) {
+				if(k.p[edit_pattern].t[track].p[k_mode][i]) {
+					monomeLedBuffer[(5 - k.p[edit_pattern].t[track].p[k_mode][i]) * 16 + i] =
+						(edit_pattern == k.pattern && i == pos[track][k_mode]) ? 10 : 6;
+				}
 			}
 		}
 		return true;

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -3363,7 +3363,7 @@ void refresh_kria_pattern(void) {
 		monomeLedBuffer[32 + meta_edit] = L2;
 		if(meta_next) {
 			monomeLedBuffer[32 + meta_next - 1] = L2;
-			monomeLedBuffer[k.meta_pat[meta_next] - 1] = L2;
+			monomeLedBuffer[k.meta_pat[meta_next]] = L2;
 		}
 	}
 	if(cue_pat_next) {

--- a/src/main.c
+++ b/src/main.c
@@ -560,11 +560,15 @@ uint8_t get_tr(uint8_t n) {
 	return gpio_get_pin_value(n);
 }
 
-void set_cv_note(uint8_t n, uint16_t note, int16_t bend) {
+void set_cv_note_noii(uint8_t n, uint16_t note, int16_t bend) {
 	outputs[n].semitones = note;
 	outputs[n].bend = bend;
 	outputs[n].dac_target = (int16_t)tuning_table[n][note] + bend;
 	dac_set_value(n, outputs[n].dac_target);
+}
+
+void set_cv_note(uint8_t n, uint16_t note, int16_t bend) {
+	set_cv_note_noii(n, note, bend);
 	for (uint8_t i = 0; i < I2C_FOLLOWER_COUNT; i++) {
 		bool play_follower = followers[i].active
 				  && followers[i].track_en & (1 << n);
@@ -802,7 +806,7 @@ int main(void)
 	print_dbg("\r\n== FLASH struct size: ");
 	print_dbg_ulong(sizeof(f));
 
-  
+
 	if(flash_is_fresh()) {
 		// store flash defaults
 		print_dbg("\r\nfirst run.");

--- a/src/main.h
+++ b/src/main.h
@@ -105,6 +105,7 @@ void set_mode(ansible_mode_t m);
 void update_leds(uint8_t m);
 void set_tr(uint8_t n);
 void clr_tr(uint8_t n);
+void set_cv_note_noii(uint8_t n, uint16_t cv, int16_t bend);
 void set_cv_note(uint8_t n, uint16_t cv, int16_t bend);
 void set_cv_slew(uint8_t n, uint16_t s);
 void reset_outputs(void);


### PR DESCRIPTION
- levels was not sending ii commands. We don't want to send a pitch update on every arc delta, so `set_cv_note_noii` just updates the DAC and updates the stored pitch, which will be sent to ii followers on the next rising edge of the gate.
- kria could crash due to an out-of-bounds access in metapattern mode. As far as I can tell removing this -1 adjustment still looks right as far as indicating the position of the metapattern playhead?