### PR TITLE
256 grid support for kria and earthsea

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -5292,7 +5292,7 @@ void handler_ESGridKey(s32 data) {
     if (es_runes || (y > 8 && !es_edge && !es_voices && (es_view == es_patterns || es_view == es_patterns_held))) {
         if (!z) return;
 
-        if (y > 8) { // show runes view on bottom half of 256
+        if (monome_size_y() > 8) { // show runes view on bottom half of 256
             y = y - 8;
         }
 

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -5292,7 +5292,7 @@ void handler_ESGridKey(s32 data) {
     if (es_runes || (monome_size_y() == 16 && y > 8 && !es_edge && !es_voices && (es_view == es_patterns || es_view == es_patterns_held))) {
         if (!z) return;
 
-        if (monome_size_y() == 16) { // show runes view on bottom half of 256 
+        if (monome_size_y() == 16) { // show runes view on bottom half of 256
             y = y - 8;
         }
 
@@ -5319,7 +5319,7 @@ void handler_ESGridKey(s32 data) {
     if (es_edge) {
         if (!z) return;
 
-        if (monome_size_y() == 16) { // show edges view on bottom half of 256 
+        if (monome_size_y() == 16) { // show edges view on bottom half of 256
             y = y - 8;
         }
 
@@ -5348,7 +5348,7 @@ void handler_ESGridKey(s32 data) {
     if (es_voices) {
         if (!z) return;
 
-        if (monome_size_y() == 16) { // show voices view on bottom half of 256 
+        if (monome_size_y() == 16) { // show voices view on bottom half of 256
             y = y - 8;
         }
 
@@ -5574,9 +5574,9 @@ void refresh_es(void) {
         }
 
         monomeLedBuffer[offset + (e.octave ? 115 : 114)] = 10 + e.octave;
-		
-		if (monome_size_y() < 16)
-			return;
+
+        if (monome_size_y() < 16)
+            return;
     }
 
     s16 index, x, y;

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -5433,80 +5433,79 @@ void refresh_es(void) {
     monomeLedBuffer[16*(15-(e.p_select % 8))] = 7;
 
     u8 l;
-    if (es_runes || (es_view == es_patterns && monome_size_y() == 16)) {
-        u8 rune_offset = (es_view == es_patterns) ? 128 : 0; // on 256, show runes on bottom half of pattern hold view 
+	u8 offset = (monome_size_y() == 16) ? 128 : 0; // on 256, show runes on bottom half of grid
+    if (es_runes) {
+        
         l = e.p[e.p_select].linearize ? 15 : 7;
 
         // linearize
-        monomeLedBuffer[rune_offset + 34] = l;
-        monomeLedBuffer[rune_offset + 36] = l;
-        monomeLedBuffer[rune_offset + 66] = l;
-        monomeLedBuffer[rune_offset + 68] = l;
+        monomeLedBuffer[offset + 34] = l;
+        monomeLedBuffer[offset + 36] = l;
+        monomeLedBuffer[offset + 66] = l;
+        monomeLedBuffer[offset + 68] = l;
 
         l = e.p[e.p_select].dir ? 15 : 7;
         // reverse
-        monomeLedBuffer[rune_offset + 39] = l;
-        monomeLedBuffer[rune_offset + 54] = l;
-        monomeLedBuffer[rune_offset + 71] = l;
+        monomeLedBuffer[offset + 39] = l;
+        monomeLedBuffer[offset + 54] = l;
+        monomeLedBuffer[offset + 71] = l;
 
         l = e.p[e.p_select].dir ? 7 : 15;
         // forward
-        monomeLedBuffer[rune_offset + 41] = l;
-        monomeLedBuffer[rune_offset + 58] = l;
-        monomeLedBuffer[rune_offset + 73] = l;
+        monomeLedBuffer[offset + 41] = l;
+        monomeLedBuffer[offset + 58] = l;
+        monomeLedBuffer[offset + 73] = l;
 
         l = 8;
         // double speed
-        monomeLedBuffer[rune_offset + 29] = l;
-        monomeLedBuffer[rune_offset + 44] = l;
-        monomeLedBuffer[rune_offset + 46] = l;
+        monomeLedBuffer[offset + 29] = l;
+        monomeLedBuffer[offset + 44] = l;
+        monomeLedBuffer[offset + 46] = l;
 
         // half speed
-        monomeLedBuffer[rune_offset + 76] = l;
-        monomeLedBuffer[rune_offset + 78] = l;
-        monomeLedBuffer[rune_offset + 93] = l;
+        monomeLedBuffer[offset + 76] = l;
+        monomeLedBuffer[offset + 78] = l;
+        monomeLedBuffer[offset + 93] = l;
 
-        if (es_runes) {
-            return;
-        }
+		return;
     }
 
     if (es_edge) {
         l = e.p[e.p_select].edge == ES_EDGE_PATTERN ? 15 : 7;
-        monomeLedBuffer[34] = l;
-        monomeLedBuffer[35] = l;
-        monomeLedBuffer[36] = l;
-        monomeLedBuffer[50] = l;
-        monomeLedBuffer[52] = l;
-        monomeLedBuffer[66] = l;
-        monomeLedBuffer[68] = l;
-        monomeLedBuffer[82] = l;
-        monomeLedBuffer[84] = l;
-        monomeLedBuffer[85] = l;
+        monomeLedBuffer[offset + 34] = l;
+        monomeLedBuffer[offset + 35] = l;
+        monomeLedBuffer[offset + 36] = l;
+        monomeLedBuffer[offset + 50] = l;
+        monomeLedBuffer[offset + 52] = l;
+        monomeLedBuffer[offset + 66] = l;
+        monomeLedBuffer[offset + 68] = l;
+        monomeLedBuffer[offset + 82] = l;
+        monomeLedBuffer[offset + 84] = l;
+        monomeLedBuffer[offset + 85] = l;
 
         l = e.p[e.p_select].edge == ES_EDGE_FIXED ? 15 : 7;
-        monomeLedBuffer[39] = l;
-        monomeLedBuffer[40] = l;
-        monomeLedBuffer[41] = l;
-        monomeLedBuffer[42] = l;
-        monomeLedBuffer[55] = l;
-        monomeLedBuffer[58] = l;
-        monomeLedBuffer[71] = l;
-        monomeLedBuffer[74] = l;
-        monomeLedBuffer[87] = l;
-        monomeLedBuffer[90] = l;
+        monomeLedBuffer[offset + 39] = l;
+        monomeLedBuffer[offset + 40] = l;
+        monomeLedBuffer[offset + 41] = l;
+        monomeLedBuffer[offset + 42] = l;
+        monomeLedBuffer[offset + 55] = l;
+        monomeLedBuffer[offset + 58] = l;
+        monomeLedBuffer[offset + 71] = l;
+        monomeLedBuffer[offset + 74] = l;
+        monomeLedBuffer[offset + 87] = l;
+        monomeLedBuffer[offset + 90] = l;
 
         l = e.p[e.p_select].edge == ES_EDGE_DRONE ? 15 : 7;
-        monomeLedBuffer[44] = l;
-        monomeLedBuffer[45] = l;
-        monomeLedBuffer[46] = l;
-        monomeLedBuffer[47] = l;
+        monomeLedBuffer[offset + 44] = l;
+        monomeLedBuffer[offset + 45] = l;
+        monomeLedBuffer[offset + 46] = l;
+        monomeLedBuffer[offset + 47] = l;
 
 		if (e.p[e.p_select].edge == ES_EDGE_FIXED) {
 			for (u8 i = 0; i < 16; i++)
-				monomeLedBuffer[112 + i] = 4;
+				monomeLedBuffer[offset + 112 + i] = 4;
             u8 edge_index = 111 + (e.p[e.p_select].edge_time >> 4);
-			if (edge_index <= 127) monomeLedBuffer[edge_index] = 11;
+			if (edge_index <= 127) monomeLedBuffer[offset + edge_index] = 11;
 		}
 
         return;
@@ -5514,11 +5513,11 @@ void refresh_es(void) {
 
     if (es_voices) {
         for (u8 i = 0; i < 4; i++) {
-            monomeLedBuffer[35 + (i << 4)] = e.voices & (1 << i) ? 15 : 4;
-            monomeLedBuffer[34 + (i << 4)] = e.p[e.p_select].voices & (1 << i) ? 15 : 4;
+            monomeLedBuffer[offset + 35 + (i << 4)] = e.voices & (1 << i) ? 15 : 4;
+            monomeLedBuffer[offset + 34 + (i << 4)] = e.p[e.p_select].voices & (1 << i) ? 15 : 4;
         }
 
-        monomeLedBuffer[e.octave ? 115 : 114] = 10 + e.octave;
+        monomeLedBuffer[offset + (e.octave ? 115 : 114)] = 10 + e.octave;
         return;
     }
 

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -3105,7 +3105,6 @@ bool refresh_kria_mod(kria_view_t* view)
 {
 	u8* monomeLedBuffer = view->buffer;
 	const u8 track = view->track;
-	//const bool k_mode_is_alt = view->mode_is_alt;
 	const kria_modes_t k_mode = view->mode;
 	const kria_mod_modes_t k_mod_mode = view->mod_mode;
 
@@ -3143,9 +3142,6 @@ bool refresh_kria_mod(kria_view_t* view)
 void refresh_kria_tr(kria_view_t* view)
 {
 	u8* monomeLedBuffer = view->buffer;
-	//const u8 track = view->track;
-	//const bool k_mode_is_alt = view->mode_is_alt;
-	//const kria_modes_t k_mode = view->mode;
 	const kria_mod_modes_t k_mod_mode = view->mod_mode;
 
 	// steps
@@ -3178,7 +3174,6 @@ void refresh_kria_note(kria_view_t* view)
 {
 	u8* monomeLedBuffer = view->buffer;
 	const u8 track = view->track;
-	//const bool k_mode_is_alt = view->mode_is_alt;
 	const kria_modes_t k_mode = view->mode;
 	const kria_mod_modes_t k_mod_mode = view->mod_mode;
 
@@ -3217,8 +3212,6 @@ void refresh_kria_oct(kria_view_t* view)
 {
 	u8* monomeLedBuffer = view->buffer;
 	const u8 track = view->track;
-	//const bool k_mode_is_alt = view->mode_is_alt;
-	//const kria_modes_t k_mode = view->mode;
 	const kria_mod_modes_t k_mod_mode = view->mod_mode;
 
 	memset(monomeLedBuffer, 2, 6);
@@ -3268,8 +3261,6 @@ void refresh_kria_dur(kria_view_t* view)
 {
 	u8* monomeLedBuffer = view->buffer;
 	const u8 track = view->track;
-	//const bool k_mode_is_alt = view->mode_is_alt;
-	//const kria_modes_t k_mode = view->mode;
 	const kria_mod_modes_t k_mod_mode = view->mod_mode;
 
 	monomeLedBuffer[k.p[edit_pattern].t[track].dur_mul - 1] = L1;
@@ -3306,8 +3297,6 @@ void refresh_kria_rpt(kria_view_t* view)
 {
 	u8* monomeLedBuffer = view->buffer;
 	const u8 track = view->track;
-	//const bool k_mode_is_alt = view->mode_is_alt;
-	//const kria_modes_t k_mode = view->mode;
 	const kria_mod_modes_t k_mod_mode = view->mod_mode;
 
 	for ( uint8_t i=0; i<16; i++ ) {
@@ -3354,8 +3343,6 @@ void refresh_kria_glide(kria_view_t* view)
 {
 	u8* monomeLedBuffer = view->buffer;
 	const u8 track = view->track;
-	//const bool k_mode_is_alt = view->mode_is_alt;
-	//const kria_modes_t k_mode = view->mode;
 	const kria_mod_modes_t k_mod_mode = view->mod_mode;
 
 	for(uint8_t i=0;i<16;i++) {
@@ -3391,10 +3378,6 @@ void refresh_kria_glide(kria_view_t* view)
 void refresh_kria_scale(kria_view_t* view)
 {
 	u8* monomeLedBuffer = view->buffer;
-	//const u8 track = view->track;
-	//const bool k_mode_is_alt = view->mode_is_alt;
-	//const kria_modes_t k_mode = view->mode;
-	//const kria_mod_modes_t k_mod_mode = view->mod_mode;
 
 	for ( uint8_t y=0; y<4; y++ ) {
 		// highlight TT clock enables and trigger steps
@@ -3435,9 +3418,6 @@ void refresh_kria_scale(kria_view_t* view)
 void refresh_kria_pattern(kria_view_t* view)
 {
 	u8* monomeLedBuffer = view->buffer;
-	//const u8 track = view->track;
-	//const bool k_mode_is_alt = view->mode_is_alt;
-	//const kria_modes_t k_mode = view->mode;
 	const kria_mod_modes_t k_mod_mode = view->mod_mode;
 
 	if(!meta) {

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -4915,8 +4915,8 @@ void default_es(void) {
         e.p_select = 0;
         e.voices = 0b1111;
         e.octave = 0;
-        for (u8 j = 0; j < 128; j++)
-            e.keymap[i] = 0;
+        for (int k = 0; k < MAX_KEYS; k++)
+            e.keymap[k] = 0;
         e.scale = 16;
         for (u8 j = 0; j < 16; j++) {
             e.p[i].interval_ind = 0;
@@ -5444,16 +5444,20 @@ void refresh_es(void) {
     s16 index, x, y;
     if (es_view == es_main) {
         if (e.scale == 16) {
-            for (u8 i = 0; i < 128; i++)
-                if (e.keymap[i]) monomeLedBuffer[i] = e.keymap[i] << 1;
+            for (x = 1; x < 16; x++) {
+                for (y = es_mode == es_playing ? 1 : 0; y < monome_size_y(); y++) {
+                    u8 i = (y << 4) + x;
+                    if (e.keymap[i]) monomeLedBuffer[i] = e.keymap[i] << 1;
+                }
+            }
         } else {
             u8 in_scale;
             for (x = 1; x < 16; x++)
-                for (y = es_mode == es_playing ? 1 : 0; y < 8; y++) {
-                    index = x + (7 - y) * 5 - 1;
+                for (y = es_mode == es_playing ? 1 : 0; y < monome_size_y(); y++) {
+                    index = x + (monome_size_y() - 1 - y) * 5 - 1;
                     in_scale = 0;
                     for (u8 sc = 0; sc < 8; sc++) {
-                        for (u8 oct = 0; oct < 5; oct++) {
+                        for (u8 oct = 0; oct < 9; oct++) {
                             if (index == cur_scale[sc] + oct * 12) {
                                 monomeLedBuffer[(y << 4) + x] = sc == 0 ? 4 : 2;
                                 in_scale = 1;

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -1787,19 +1787,6 @@ void handler_KriaGridKey(s32 data) {
 					}
 				}
 			}
-			else if ((k_views[0].mode == mPattern && y == 0 ) || (k_views[1].mode == mPattern && y == 8)) {
-				if(!meta) {
-					if(cue) {
-						cue_pat_next = x+1;
-					}
-					else {
-						change_pattern(x);
-					}
-				}
-				else if(!cue) {
-					k.meta_pat[meta_edit] = x;
-				}
-			}
 			else if(view_tuning) {
 				if (y == 5) {
 					if (x == 11) {
@@ -1812,6 +1799,19 @@ void handler_KriaGridKey(s32 data) {
 						fit_tuning(1);
 						restore_grid_tuning();
 					}
+				}
+			}
+			else if ((k_views[0].mode == mPattern && y == 0 ) || (k_views[1].mode == mPattern && y == 8)) {
+				if(!meta) {
+					if(cue) {
+						cue_pat_next = x+1;
+					}
+					else {
+						change_pattern(x);
+					}
+				}
+				else if(!cue) {
+					k.meta_pat[meta_edit] = x;
 				}
 			}
 		}
@@ -5289,10 +5289,10 @@ void handler_ESGridKey(s32 data) {
         return;
     }
 
-    if (es_runes || (monome_size_y() == 16 && y > 8 && !es_edge && !es_voices && (es_view == es_patterns || es_view == es_patterns_held))) {
+    if (es_runes || (y > 8 && !es_edge && !es_voices && (es_view == es_patterns || es_view == es_patterns_held))) {
         if (!z) return;
 
-        if (monome_size_y() == 16) { // show runes view on bottom half of 256
+        if (y > 8) { // show runes view on bottom half of 256
             y = y - 8;
         }
 

--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -1586,6 +1586,8 @@ static void kria_set_alt_blink_timer(kria_view_t* views) {
 		if ( views[i].mode == mRpt || views[i].mode == mAltNote || views[i].mode == mGlide ) {
 			any_view_is_alt = true;
 			views[i].mode_is_alt = true;
+		} else {
+			views[i].mode_is_alt = false;
 		}
 	}
 	timer_remove( &altBlinkTimer );	
@@ -3012,9 +3014,7 @@ void refresh_kria_view(kria_view_t* view)
 {
 	u8* monomeLedBuffer = view->buffer;
 	const u8 track = view->track;
-	const bool k_mode_is_alt = view->mode_is_alt;
 	const kria_modes_t k_mode = view->mode;
-	//const kria_mod_modes_t k_mod_mode = view->mod_mode;
 
 	memset(monomeLedBuffer, 0, 128);
 
@@ -3065,7 +3065,7 @@ void refresh_kria_view(kria_view_t* view)
 		monomeLedBuffer[activeModeIndex] = (meta && meta_lock && kriaMetaLockBlink) ? L1 : L2;
 	}
 	else {
-		monomeLedBuffer[activeModeIndex] = (k_mode_is_alt && kriaAltModeBlink) ? L1 : L2;
+		monomeLedBuffer[activeModeIndex] = (view->mode_is_alt && kriaAltModeBlink) ? L1 : L2;
 	}
 
 

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -98,7 +98,22 @@ typedef struct {
 	kria_data_t k[GRID_PRESETS];
 } kria_state_t;
 
+typedef enum {
+	mTr, mNote, mOct, mDur, mRpt, mAltNote, mGlide, mScale, mPattern
+} kria_modes_t;
 
+typedef enum {
+	modNone, modLoop, modTime, modProb
+} kria_mod_modes_t;
+
+typedef struct {
+	u8 track;
+	kria_modes_t mode;
+	kria_mod_modes_t mod_mode;
+	bool mode_is_alt;
+	u8* buffer;
+	softTimer_t* altBlinkTimer;
+} kria_view_t;
 
 
 typedef struct {
@@ -219,15 +234,16 @@ void handler_KriaKey(s32 data);
 void handler_KriaTr(s32 data);
 void handler_KriaTrNormal(s32 data);
 void refresh_kria(void);
-bool refresh_kria_mod(void);
-void refresh_kria_tr(void);
-void refresh_kria_note(bool isAlt);
-void refresh_kria_oct(void);
-void refresh_kria_dur(void);
-void refresh_kria_rpt(void);
-void refresh_kria_glide(void);
-void refresh_kria_scale(void);
-void refresh_kria_pattern(void);
+void refresh_kria_view(kria_view_t* view);
+bool refresh_kria_mod(kria_view_t* view);
+void refresh_kria_tr(kria_view_t* view);
+void refresh_kria_note(kria_view_t* view);
+void refresh_kria_oct(kria_view_t* view);
+void refresh_kria_dur(kria_view_t* view);
+void refresh_kria_rpt(kria_view_t* view);
+void refresh_kria_glide(kria_view_t* view);
+void refresh_kria_scale(kria_view_t* view);
+void refresh_kria_pattern(kria_view_t* view);
 void refresh_kria_config(void);
 
 void default_mp(void);

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -199,7 +199,7 @@ typedef struct {
 	u8 voices;
 	u8 octave;
 	u8 scale;
-	u16 keymap[128];
+	u8 keymap[256];
 	es_pattern_t p[16];
 	u8 glyph[8];
 } es_data_t;

--- a/src/ansible_grid.h
+++ b/src/ansible_grid.h
@@ -114,7 +114,6 @@ typedef struct {
 	kria_mod_modes_t mod_mode;
 	bool mode_is_alt;
 	u8* buffer;
-	softTimer_t* altBlinkTimer;
 } kria_view_t;
 
 

--- a/tools/flash_tools/schemata/ansible/vnext.py
+++ b/tools/flash_tools/schemata/ansible/vnext.py
@@ -203,7 +203,7 @@ typedef struct {
 	u8 voices;
 	u8 octave;
 	u8 scale;
-	u16 keymap[128];
+	u8 keymap[256];
 	es_pattern_t p[16];
 	u8 glyph[8];
 } es_data_t;


### PR DESCRIPTION
This is a long overdue PR of 256 grid support for kria that I've been using in sporadic live performances over the past couple years. In 2020 I reapplied the changes to the 3.0 firmware and I think I've worked out the obvious bugs. Last year I also took a swing at 256 support for Earthsea.

![image](https://user-images.githubusercontent.com/712405/126231776-3e35912b-92c3-4592-bd34-05f620687602.png)

Kria changes:
* Using a 256 grid will show two independent kria views on the top and bottom halves of the grid. You can independently set mode, alt mode, modifier, etc. for the two views, or work on different tracks in the same mode.

Earthsea changes:
* Using a 256 grid will extend the playing surface over the entire grid. The extra space in column 0 is used for pattern-switching.
* With a 256 grid, the rune, edge, and voice views will appear on the lower half of the grid. In pattern view, the runes will be shown on the lower half of the grid.

Things that don't change:
* The kria time and config views continue to just use the top half of the grid.
* Meadowphysics still uses just the top half of the grid. (Possible future enhancement: bring over @scanner-darkly's 256 support from the original trilogy module.)
* Kria metapattern lock applies simultaneously to both views, so you can still only edit one pattern at a time. (Possible future enhancement: support locking one view and leaving the other to follow the playing pattern, or support locking both views independently to separate patterns.)
* Earthsea still doesn't let you have both a playing surface and one of the rune/pattern/edge views visible at the same time. (Possible future enhancement.)
* ii commands relating to kria mode act as if the top view was the only view. (not tested)
* This changes the size of the earthsea keymap array but not the memory footprint due to the switch from `u16` to `u8`. This might be a bad idea?

I finally got a 128 in the latest batch, so I was able to do some basic testing to confirm things continue to work exactly the same for 128 users. But these are deep apps and I'm sure I'm not using every nook and cranny. This should get some beta testing by 256 and 128 users, which I'll solicit on lines and discord(s). Also, this may not be the most desirable way to use the extra space on the 256 -- would definitely welcome feedback on alternative approaches!