### PR TITLE
add a bootup delay when in leader mode

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -719,6 +719,8 @@ void load_flash_state(void) {
 		if (followers[i].active) {
 			if (!leader_mode) {
 				leader_mode = true;
+				// wait to allow for any i2c devices to fully initalise
+				delay_ms(1500);
 				init_i2c_leader();
 			}
 			follower_on(i);


### PR DESCRIPTION
this is a fix to allow some follower devices to work properly with ansible running as i2c leader - this is the same delay teletype uses.
relevant discussion on lines: https://llllllll.co/t/i2c2midi-a-diy-module-that-translates-i2c-to-midi/40950/78

