### PR TITLE
MP grid key handler should ignore bottom half of 256/zero

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -4018,6 +4018,10 @@ void handler_MPGridKey(s32 data) {
 	// print_dbg("; z: 0x");
 	// print_dbg_hex(z);
 
+	if (y > 7) {
+		return;
+	}
+
 	//// TRACK LONG PRESSES
 	index = y*16 + x;
 	if(z) {


### PR DESCRIPTION
Got a report on the teletype study group discord that certain presses on the bottom half of a zero hang ansible when in meadowphysics mode. Previous PR #99 didn't touch MP, but this basic protection should probably have been part of that.

(Bringing over some version of scanner's [standalone meadowphysics 256 branch](https://github.com/monome/meadowphysics/compare/main...scanner-darkly:meadowphysics:grid256) would be a good follow up, looking at how much work that would be.)