### PR TITLE
Fix ii mute bug on preset load

### DIFF
--- a/src/ansible_ii_leader.c
+++ b/src/ansible_ii_leader.c
@@ -525,16 +525,14 @@ static void ii_mode_wsyn(i2c_follower_t* follower, uint8_t track, uint8_t mode) 
 }
 
 static void ii_mute_wsyn(i2c_follower_t* follower, uint8_t track, uint8_t mode) {
-	uint8_t d[6] = { 0 };
+	uint8_t d[4] = { 0 };
 
 	// clear all triggers to avoid hanging notes in SUSTAIN
-	d[0] = WS_S_VOX;
+	d[0] = WS_S_VEL;
 	d[1] = 0;
 	d[2] = 0;
 	d[3] = 0;
-	d[4] = 0;
-	d[5] = 0;
-	i2c_leader_tx(follower->addr, d, 6);
+	i2c_leader_tx(follower->addr, d, 4);
 }
 
 static void ii_cv_wsyn(i2c_follower_t* follower, uint8_t track, uint16_t dac_value) {

--- a/src/main.c
+++ b/src/main.c
@@ -601,7 +601,7 @@ void reset_outputs(void) {
 			bool play_follower = followers[i].active
 			  && followers[i].track_en & (1 << n);
 			if (play_follower) {
-				followers[i].ops->mute(&followers[n], 0, 0);
+				followers[i].ops->mute(&followers[i], 0, 0);
 			}
 		}
 	}


### PR DESCRIPTION
I was experiencing an ii freeze of txo and wsyn when powering on Ansible or loading a preset, if both txo and wsyn were enabled as followers. However, when having just one of them enabled during the load, and then only after the load enabling the other follower via the config page, things would work fine. Looking into it, this appears to be a bug in `reset_outputs()` in `src/main.c`, which loops through the 4 tracks and for each ii follower that is enabled for that track, calls its `mute` function. It looks like `n`, which represents the track number, was accidentally used instead of `i`, the index of the the ii follower, when getting the ii follower from `followers` and passing it to `mute`. Making this change resolved this freezing issue for me.

`reset_outputs` is called by the `resume_*` functions for the apps (ex. `resume_kria()`). For example, I believe the chain of calls when loading a preset in Kria via the grid is `handler_KriaGridKey`->`resume_kria`->`reset_outputs`. It's actually not clear to me how `reset_outputs` is getting called when the module is powered on, but I'm pretty sure it's being called somewhere in there because my ii follower freeze bug was happening in the same way both when powering on the module, and loading a preset in kria via the grid, and the bug is resolved in both situations with this change. Let me know if you want me to investigate this further and I can pin it down.

The 2nd commit in this PR changes the wsyn mute function (`ii_mute_wsyn()`) to use `WS_S_VEL` to set velocity to 0 for all voices, instead of using `WS_S_VOX` to set both velocity and pitch to 0 for all channels. This is because setting the pitch to 0 can create sudden undesirable pitch jumps when loading a preset (or just reloading the current preset). Setting velocity to 0 for all voices should be sufficient to "mute" the voices and prevent infinite sustain, and this is the approach used in `ii_init_wsyn()`. If this change is not desired, I can simply drop the commit.