### PR TITLE
fix bug when selecting preset with external clock

### DIFF
--- a/src/ansible_grid.c
+++ b/src/ansible_grid.c
@@ -1770,6 +1770,7 @@ void handler_KriaGridKey(s32 data) {
 						for(i1=0;i1<8;i1++)
 							k.glyph[i1] = f.kria_state.k[preset].glyph[i1];
 
+						monomeFrameDirty++;
 						// print_dbg("\r\npreset select:");
 						// print_dbg_ulong(preset);
 					}


### PR DESCRIPTION
when externally clocked (cable in the clock jack) but no clock is actually being received, presses in the first column of the preset page to select preset would not display until another key was pressed - however, the preset being operated on would be changed. Setting the grid dirty flag when changing the selected preset, instead of waiting for a clock to do it, solves this